### PR TITLE
[FEAT/#4] navigation 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
-            android:name=".feature.MainActivity"
+            android:name=".feature.main.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:screenOrientation="portrait"

--- a/app/src/main/java/org/sopt/linkareer/core/navigation/MainTabRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/navigation/MainTabRoute.kt
@@ -1,0 +1,20 @@
+package org.sopt.linkareer.core.navigation
+
+import kotlinx.serialization.Serializable
+
+interface MainTabRoute : Route
+
+@Serializable
+data object Menu : MainTabRoute
+
+@Serializable
+data object Community : MainTabRoute
+
+@Serializable
+data object Home : MainTabRoute
+
+@Serializable
+data object Calendar : MainTabRoute
+
+@Serializable
+data object Chatting : MainTabRoute

--- a/app/src/main/java/org/sopt/linkareer/core/navigation/Route.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/navigation/Route.kt
@@ -1,0 +1,3 @@
+package org.sopt.linkareer.core.navigation
+
+interface Route

--- a/app/src/main/java/org/sopt/linkareer/core/util/NoRippleInteraction.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/util/NoRippleInteraction.kt
@@ -1,0 +1,15 @@
+package org.sopt.linkareer.core.util
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+object NoRippleInteraction : MutableInteractionSource {
+
+    override val interactions: Flow<Interaction> = emptyFlow()
+
+    override suspend fun emit(interaction: Interaction) {}
+
+    override fun tryEmit(interaction: Interaction): Boolean = true
+}

--- a/app/src/main/java/org/sopt/linkareer/core/util/NoRippleInteraction.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/util/NoRippleInteraction.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
 object NoRippleInteraction : MutableInteractionSource {
-
     override val interactions: Flow<Interaction> = emptyFlow()
 
     override suspend fun emit(interaction: Interaction) {}

--- a/app/src/main/java/org/sopt/linkareer/feature/chatting/ChattingRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/chatting/ChattingRoute.kt
@@ -1,0 +1,28 @@
+package org.sopt.linkareer.feature.chatting
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ChattingRoute(
+    paddingValues: PaddingValues,
+) {
+    ChattingScreen(paddingValues)
+}
+
+@Composable
+fun ChattingScreen(
+    paddingValues: PaddingValues,
+) {
+    Column(
+        modifier =
+            Modifier
+                .padding(paddingValues),
+    ) {
+        Text("Chatting")
+    }
+}

--- a/app/src/main/java/org/sopt/linkareer/feature/chatting/navigation/ChattingNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/chatting/navigation/ChattingNavigation.kt
@@ -1,0 +1,26 @@
+package org.sopt.linkareer.feature.chatting.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import org.sopt.linkareer.core.navigation.Chatting
+import org.sopt.linkareer.feature.chatting.ChattingRoute
+
+fun NavController.navigateToChatting(navOptions: NavOptions? = null) {
+    navigate(
+        route = Chatting,
+        navOptions = navOptions,
+    )
+}
+
+fun NavGraphBuilder.chattingGraph(
+    paddingValues: PaddingValues,
+    navHostController: NavHostController,
+) {
+    composable<Chatting> {
+        ChattingRoute(paddingValues)
+    }
+}

--- a/app/src/main/java/org/sopt/linkareer/feature/home/HomeRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/home/HomeRoute.kt
@@ -1,0 +1,26 @@
+package org.sopt.linkareer.feature.home
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun HomeRoute(
+    paddingValues: PaddingValues,
+) {
+    HomeScreen(paddingValues)
+}
+
+@Composable
+fun HomeScreen(
+    paddingValues: PaddingValues,
+) {
+    Column(
+        modifier = Modifier.padding(paddingValues),
+    ) {
+        Text("HOME")
+    }
+}

--- a/app/src/main/java/org/sopt/linkareer/feature/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/home/navigation/HomeNavigation.kt
@@ -1,0 +1,26 @@
+package org.sopt.linkareer.feature.home.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import org.sopt.linkareer.core.navigation.Home
+import org.sopt.linkareer.feature.home.HomeRoute
+
+fun NavController.navigateToHome(navOptions: NavOptions? = null) {
+    navigate(
+        route = Home,
+        navOptions = navOptions,
+    )
+}
+
+fun NavGraphBuilder.homeNavGraph(
+    paddingValues: PaddingValues,
+    navHostController: NavHostController,
+) {
+    composable<Home> {
+        HomeRoute(paddingValues)
+    }
+}

--- a/app/src/main/java/org/sopt/linkareer/feature/main/MainActivity.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/main/MainActivity.kt
@@ -1,4 +1,4 @@
-package org.sopt.linkareer.feature
+package org.sopt.linkareer.feature.main
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -6,7 +6,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.linkareer.core.designsystem.LINKareerAndroidTheme
-import org.sopt.linkareer.feature.dummy.DummyScreen
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -14,8 +13,9 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
+            val navigator = rememberMainNavigator()
             LINKareerAndroidTheme {
-                DummyScreen()
+                MainScreen(navigator)
             }
         }
     }

--- a/app/src/main/java/org/sopt/linkareer/feature/main/MainNavigator.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/main/MainNavigator.kt
@@ -1,0 +1,68 @@
+package org.sopt.linkareer.feature.main
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.navigation.NavDestination
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navOptions
+import org.sopt.linkareer.core.navigation.Home
+import org.sopt.linkareer.feature.chatting.navigation.navigateToChatting
+import org.sopt.linkareer.feature.home.navigation.navigateToHome
+
+class MainNavigator(
+    val navController: NavHostController,
+) {
+    private val currentDestination: NavDestination?
+        @Composable get() =
+            navController
+                .currentBackStackEntryAsState().value?.destination
+
+    val startDestination = Home
+
+    val currentTab: MainTab?
+        @Composable get() =
+            MainTab.find { tab ->
+                currentDestination?.hasRoute(tab::class) == true
+            }
+
+    fun navigate(tab: MainTab) {
+        val navOptions =
+            navOptions {
+                navController.currentDestination?.route?.let {
+                    popUpTo(it) {
+                        inclusive = true
+                        saveState = true
+                    }
+                }
+                launchSingleTop = true
+                restoreState = true
+            }
+
+        when (tab) {
+            MainTab.HOME -> navController.navigateToHome(navOptions)
+            MainTab.CHATTING -> navController.navigateToChatting(navOptions)
+            else -> {}
+        }
+    }
+
+    fun navigateUp() {
+        navController.navigateUp()
+    }
+
+    @Composable
+    fun showBottomBar() =
+        MainTab.contains {
+            currentDestination?.hasRoute(it::class) == true
+        }
+}
+
+@Composable
+fun rememberMainNavigator(
+    navController: NavHostController = rememberNavController(),
+): MainNavigator =
+    remember(navController) {
+        MainNavigator(navController)
+    }

--- a/app/src/main/java/org/sopt/linkareer/feature/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/main/MainScreen.kt
@@ -19,6 +19,7 @@ import org.sopt.linkareer.core.designsystem.Gray600
 import org.sopt.linkareer.core.designsystem.Gray900
 import org.sopt.linkareer.core.designsystem.LINKareerTheme
 import org.sopt.linkareer.core.designsystem.White
+import org.sopt.linkareer.core.util.NoRippleInteraction
 import org.sopt.linkareer.feature.chatting.navigation.chattingGraph
 import org.sopt.linkareer.feature.home.navigation.homeNavGraph
 
@@ -80,6 +81,7 @@ private fun MainBottomBar(
     NavigationBar(containerColor = White) {
         tabs.forEach { itemType ->
             NavigationBarItem(
+                interactionSource = NoRippleInteraction,
                 selected = currentTab == itemType,
                 onClick = {
                     onTabSelected(itemType)

--- a/app/src/main/java/org/sopt/linkareer/feature/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/main/MainScreen.kt
@@ -12,11 +12,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.compose.NavHost
-import org.sopt.linkareer.core.designsystem.Black
+import org.sopt.linkareer.core.designsystem.Gray600
+import org.sopt.linkareer.core.designsystem.Gray900
 import org.sopt.linkareer.core.designsystem.LINKareerTheme
 import org.sopt.linkareer.core.designsystem.White
 import org.sopt.linkareer.feature.chatting.navigation.chattingGraph
@@ -98,13 +98,13 @@ private fun MainBottomBar(
                 },
                 colors =
                     NavigationBarItemColors(
-                        selectedIconColor = Color.Blue,
-                        selectedTextColor = Black,
+                        selectedIconColor = Gray900,
+                        selectedTextColor = Gray900,
                         selectedIndicatorColor = White,
-                        unselectedIconColor = Black,
-                        unselectedTextColor = Black,
-                        disabledTextColor = Black,
-                        disabledIconColor = Black,
+                        unselectedIconColor = Gray600,
+                        unselectedTextColor = Gray600,
+                        disabledTextColor = Gray600,
+                        disabledIconColor = Gray600,
                     ),
             )
         }

--- a/app/src/main/java/org/sopt/linkareer/feature/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/main/MainScreen.kt
@@ -1,0 +1,112 @@
+package org.sopt.linkareer.feature.main
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemColors
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.compose.NavHost
+import org.sopt.linkareer.core.designsystem.Black
+import org.sopt.linkareer.core.designsystem.LINKareerTheme
+import org.sopt.linkareer.core.designsystem.White
+import org.sopt.linkareer.feature.chatting.navigation.chattingGraph
+import org.sopt.linkareer.feature.home.navigation.homeNavGraph
+
+@Composable
+fun MainScreen(
+    navigator: MainNavigator,
+) {
+    Scaffold(
+        bottomBar = {
+            if (navigator.showBottomBar()) {
+                MainBottomBar(
+                    tabs = MainTab.entries.toList(),
+                    currentTab = navigator.currentTab,
+                    onTabSelected = navigator::navigate,
+                )
+            }
+        },
+    ) { paddingValues ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize(),
+        ) {
+            NavHost(
+                enterTransition = {
+                    EnterTransition.None
+                },
+                exitTransition = {
+                    ExitTransition.None
+                },
+                popEnterTransition = {
+                    EnterTransition.None
+                },
+                popExitTransition = {
+                    ExitTransition.None
+                },
+                navController = navigator.navController,
+                startDestination = navigator.startDestination,
+            ) {
+                homeNavGraph(
+                    paddingValues = paddingValues,
+                    navHostController = navigator.navController,
+                )
+                chattingGraph(
+                    paddingValues = paddingValues,
+                    navHostController = navigator.navController,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MainBottomBar(
+    tabs: List<MainTab>,
+    currentTab: MainTab?,
+    onTabSelected: (MainTab) -> Unit,
+) {
+    NavigationBar(containerColor = White) {
+        tabs.forEach { itemType ->
+            NavigationBarItem(
+                selected = currentTab == itemType,
+                onClick = {
+                    onTabSelected(itemType)
+                },
+                icon = {
+                    Image(
+                        painter = painterResource(id = if (currentTab == itemType) itemType.selectedIcon else itemType.unselectedIcon),
+                        contentDescription = stringResource(id = itemType.contentDescription),
+                    )
+                },
+                label = {
+                    Text(
+                        stringResource(id = itemType.contentDescription),
+                        style = LINKareerTheme.typography.label4M10,
+                    )
+                },
+                colors =
+                    NavigationBarItemColors(
+                        selectedIconColor = Color.Blue,
+                        selectedTextColor = Black,
+                        selectedIndicatorColor = White,
+                        unselectedIconColor = Black,
+                        unselectedTextColor = Black,
+                        disabledTextColor = Black,
+                        disabledIconColor = Black,
+                    ),
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/sopt/linkareer/feature/main/MainTab.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/main/MainTab.kt
@@ -1,0 +1,63 @@
+package org.sopt.linkareer.feature.main
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import org.sopt.linkareer.R
+import org.sopt.linkareer.core.navigation.Calendar
+import org.sopt.linkareer.core.navigation.Chatting
+import org.sopt.linkareer.core.navigation.Community
+import org.sopt.linkareer.core.navigation.Home
+import org.sopt.linkareer.core.navigation.MainTabRoute
+import org.sopt.linkareer.core.navigation.Menu
+import org.sopt.linkareer.core.navigation.Route
+
+enum class MainTab(
+    @DrawableRes val selectedIcon: Int,
+    @DrawableRes val unselectedIcon: Int,
+    @StringRes val contentDescription: Int,
+    val route: MainTabRoute,
+) {
+    MENU(
+        selectedIcon = R.drawable.ic_menu_active_32,
+        unselectedIcon = R.drawable.ic_menu_inactive_32,
+        contentDescription = R.string.menu,
+        route = Menu,
+    ),
+    COMMUNITY(
+        selectedIcon = R.drawable.ic_community_active_32,
+        unselectedIcon = R.drawable.ic_community_inactive_32,
+        contentDescription = R.string.community,
+        route = Community,
+    ),
+    HOME(
+        selectedIcon = R.drawable.ic_home_active_32,
+        unselectedIcon = R.drawable.ic_home_inactive_32,
+        contentDescription = R.string.home,
+        route = Home,
+    ),
+    CALENDAR(
+        selectedIcon = R.drawable.ic_calendar_active_32,
+        unselectedIcon = R.drawable.ic_calendar_inactive_32,
+        contentDescription = R.string.calendar,
+        route = Calendar,
+    ),
+    CHATTING(
+        selectedIcon = R.drawable.ic_chatting_active_32,
+        unselectedIcon = R.drawable.ic_chatting_inactive_32,
+        contentDescription = R.string.chatting,
+        route = Chatting,
+    ), ;
+
+    companion object {
+        @Composable
+        fun find(predicate: @Composable (MainTabRoute) -> Boolean): MainTab? {
+            return entries.find { predicate(it.route) }
+        }
+
+        @Composable
+        fun contains(predicate: @Composable (Route) -> Boolean): Boolean {
+            return entries.map { it.route }.any { predicate(it) }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,10 @@
 <resources>
     <string name="app_name">LINKareer-Android</string>
+
+    <!-- bottom navigation -->
+    <string name="menu">메뉴</string>
+    <string name="community">커뮤니티</string>
+    <string name="home">홈</string>
+    <string name="calendar">공고달력</string>
+    <string name="chatting">채팅</string>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #4 

## Work Description ✏️
- Jetpack Navigation + SAA 구현

## Screenshot 📸
https://github.com/user-attachments/assets/48f92f31-e3d7-46b6-ad11-e37b7372fc51


## Uncompleted Tasks 😅
- 없습니다!

## To Reviewers 📢
- 홈, 채팅을 제외한 다른 탭은 화면 이동 없도록 구현했습니다!
- 채팅화면으로 넘어갈 때 바텀바가 살짝 깜빡거리는데 이건 왜 그런걸까요🤔 
