### PR TITLE
Feat/#21 tapbar component

### DIFF
--- a/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/HomeTapBar.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/HomeTapBar.kt
@@ -1,6 +1,7 @@
 package org.sopt.linkareer.core.designsystem.component.tapbar
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -28,6 +29,7 @@ import org.sopt.linkareer.R
 import org.sopt.linkareer.core.designsystem.theme.Blue
 import org.sopt.linkareer.core.designsystem.theme.Gray900
 import org.sopt.linkareer.core.designsystem.theme.LINKareerAndroidTheme
+import org.sopt.linkareer.core.designsystem.theme.White
 import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 
 @Composable
@@ -42,6 +44,7 @@ fun HomeTapBar(
         modifier =
             Modifier
                 .fillMaxWidth()
+                .background(White)
                 .padding(start = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/HomeTapBar.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/HomeTapBar.kt
@@ -1,0 +1,130 @@
+package org.sopt.linkareer.core.designsystem.component.tapbar
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color.Companion.Transparent
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.linkareer.R
+import org.sopt.linkareer.core.designsystem.theme.Blue
+import org.sopt.linkareer.core.designsystem.theme.Gray900
+import org.sopt.linkareer.core.designsystem.theme.LINKareerAndroidTheme
+import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
+
+@Composable
+fun HomeTapBar(
+    onTabClick: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val newbieTab  = stringResource(R.string.home_tab_newbie)
+    var rememberTap by remember { mutableStateOf<String?>(null) }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        TabItem(
+            tapName = newbieTab ,
+            isSelected = rememberTap == newbieTab,
+            onClick = {
+                rememberTap = newbieTab
+                onTabClick(newbieTab)
+            }
+        )
+        Spacer(modifier = Modifier.padding(start = 12.dp))
+
+        TabItem(
+            tapName = stringResource(R.string.home_tab_contest),
+            isSelected = false
+        )
+        Spacer(modifier = Modifier.padding(start = 12.dp))
+
+        TabItem(
+            tapName = stringResource(R.string.home_tab_channel),
+            isSelected = false
+        )
+        Spacer(modifier = Modifier.padding(start = 12.dp))
+
+        TabItem(
+            tapName = stringResource(R.string.home_tab_community),
+            isSelected = false
+        )
+
+        Image(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_down_box_30),
+            contentDescription = stringResource(R.string.newbie_tab_arrow_down_contentDescription),
+        )
+    }
+}
+
+@Composable
+fun TabItem(
+    tapName: String,
+    isSelected: Boolean,
+    onClick: (() -> Unit)? = null
+) {
+    Box(
+        modifier = Modifier
+            .clickable { if (onClick != null) onClick() }
+            .width(IntrinsicSize.Max)
+            .drawBehind {
+                if (isSelected) {
+                    drawLine(
+                        color = Blue,
+                        start = Offset(0f, size.height),
+                        end = Offset(size.width, size.height),
+                        strokeWidth = 2.dp.toPx()
+                    )
+                }
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = tapName,
+            style = defaultLINKareerTypography.title5B14,
+            color = if (isSelected) Blue else Gray900,
+            modifier = Modifier
+                .padding(vertical = 12.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HomeTapBarPreview() {
+    LINKareerAndroidTheme {
+        HomeTapBar(
+            onTabClick = {}
+        )
+    }
+}

--- a/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/HomeTapBar.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/HomeTapBar.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text

--- a/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/HomeTapBar.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/HomeTapBar.kt
@@ -1,22 +1,15 @@
 package org.sopt.linkareer.core.designsystem.component.tapbar
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -27,7 +20,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color.Companion.Transparent
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -42,42 +34,43 @@ import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 @Composable
 fun HomeTapBar(
     onTabClick: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
-    val newbieTab  = stringResource(R.string.home_tab_newbie)
+    val newbieTab = stringResource(R.string.home_tab_newbie)
     var rememberTap by remember { mutableStateOf<String?>(null) }
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 10.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(start = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         TabItem(
-            tapName = newbieTab ,
+            tapName = newbieTab,
             isSelected = rememberTap == newbieTab,
             onClick = {
                 rememberTap = newbieTab
                 onTabClick(newbieTab)
-            }
+            },
         )
         Spacer(modifier = Modifier.padding(start = 12.dp))
 
         TabItem(
             tapName = stringResource(R.string.home_tab_contest),
-            isSelected = false
+            isSelected = false,
         )
         Spacer(modifier = Modifier.padding(start = 12.dp))
 
         TabItem(
             tapName = stringResource(R.string.home_tab_channel),
-            isSelected = false
+            isSelected = false,
         )
         Spacer(modifier = Modifier.padding(start = 12.dp))
 
         TabItem(
             tapName = stringResource(R.string.home_tab_community),
-            isSelected = false
+            isSelected = false,
         )
 
         Image(
@@ -91,30 +84,32 @@ fun HomeTapBar(
 fun TabItem(
     tapName: String,
     isSelected: Boolean,
-    onClick: (() -> Unit)? = null
+    onClick: (() -> Unit)? = null,
 ) {
     Box(
-        modifier = Modifier
-            .clickable { if (onClick != null) onClick() }
-            .width(IntrinsicSize.Max)
-            .drawBehind {
-                if (isSelected) {
-                    drawLine(
-                        color = Blue,
-                        start = Offset(0f, size.height),
-                        end = Offset(size.width, size.height),
-                        strokeWidth = 2.dp.toPx()
-                    )
-                }
-            },
+        modifier =
+            Modifier
+                .clickable { if (onClick != null) onClick() }
+                .width(IntrinsicSize.Max)
+                .drawBehind {
+                    if (isSelected) {
+                        drawLine(
+                            color = Blue,
+                            start = Offset(0f, size.height),
+                            end = Offset(size.width, size.height),
+                            strokeWidth = 2.dp.toPx(),
+                        )
+                    }
+                },
         contentAlignment = Alignment.Center,
     ) {
         Text(
             text = tapName,
             style = defaultLINKareerTypography.title5B14,
             color = if (isSelected) Blue else Gray900,
-            modifier = Modifier
-                .padding(vertical = 12.dp)
+            modifier =
+                Modifier
+                    .padding(vertical = 12.dp),
         )
     }
 }
@@ -124,7 +119,7 @@ fun TabItem(
 fun HomeTapBarPreview() {
     LINKareerAndroidTheme {
         HomeTapBar(
-            onTabClick = {}
+            onTabClick = {},
         )
     }
 }

--- a/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/InternTapBar.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/InternTapBar.kt
@@ -1,5 +1,6 @@
 package org.sopt.linkareer.core.designsystem.component.tapbar
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -18,6 +19,7 @@ import org.sopt.linkareer.R
 import org.sopt.linkareer.core.designsystem.theme.Blue
 import org.sopt.linkareer.core.designsystem.theme.Gray900
 import org.sopt.linkareer.core.designsystem.theme.LINKareerAndroidTheme
+import org.sopt.linkareer.core.designsystem.theme.White
 import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 
 @Composable
@@ -28,6 +30,7 @@ fun InternTapBar(
         modifier =
             Modifier
                 .fillMaxWidth()
+                .background(White)
                 .padding(start = 17.dp, end = 120.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/InternTapBar.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/InternTapBar.kt
@@ -28,7 +28,7 @@ fun InternTapBar(
 ) {
     Row(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .background(White)
                 .padding(start = 17.dp, end = 120.dp),

--- a/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/InternTapBar.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/InternTapBar.kt
@@ -1,0 +1,79 @@
+package org.sopt.linkareer.core.designsystem.component.tapbar
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.linkareer.R
+import org.sopt.linkareer.core.designsystem.theme.Blue
+import org.sopt.linkareer.core.designsystem.theme.Gray900
+import org.sopt.linkareer.core.designsystem.theme.LINKareerAndroidTheme
+import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
+
+@Composable
+fun InternTapBar(
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 17.dp, end = 120.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        InternTabItem(
+            tapName = stringResource(R.string.newbie_tab_home),
+        )
+        Spacer(modifier = Modifier.padding(start = 16.dp))
+
+        InternTabItem(
+            tapName = stringResource(R.string.newbie_tab_intern),
+        )
+        Spacer(modifier = Modifier.padding(start = 16.dp))
+
+        InternTabItem(
+            tapName = stringResource(R.string.newbie_tab_newbie),
+        )
+        Spacer(modifier = Modifier.padding(start = 16.dp))
+
+        InternTabItem(
+            tapName = stringResource(R.string.newbie_tab_calendar),
+        )
+    }
+}
+
+@Composable
+fun InternTabItem(
+    tapName: String,
+) {
+    Box(
+        modifier = Modifier
+            .width(IntrinsicSize.Max),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = tapName,
+            style = defaultLINKareerTypography.body7M14,
+            color = if (tapName == stringResource(R.string.newbie_tab_home)) Blue else Gray900,
+            modifier = Modifier
+                .padding(vertical = 12.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun InternTapBarPreview() {
+    LINKareerAndroidTheme {
+        InternTapBar()
+    }
+}

--- a/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/InternTapBar.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/InternTapBar.kt
@@ -22,12 +22,13 @@ import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 
 @Composable
 fun InternTapBar(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 17.dp, end = 120.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(start = 17.dp, end = 120.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         InternTabItem(
@@ -56,16 +57,18 @@ fun InternTabItem(
     tapName: String,
 ) {
     Box(
-        modifier = Modifier
-            .width(IntrinsicSize.Max),
+        modifier =
+            Modifier
+                .width(IntrinsicSize.Max),
         contentAlignment = Alignment.Center,
     ) {
         Text(
             text = tapName,
             style = defaultLINKareerTypography.body7M14,
             color = if (tapName == stringResource(R.string.newbie_tab_home)) Blue else Gray900,
-            modifier = Modifier
-                .padding(vertical = 12.dp)
+            modifier =
+                Modifier
+                    .padding(vertical = 12.dp),
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,4 +61,18 @@
 
     <!-- Top App Bar -->
     <string name="chatting_room_head_count">%s명</string>
+
+    <!-- TapBar -->
+    <string name="home_tab_newbie">신입/인턴</string>
+    <string name="home_tab_contest">대외활동/교육/공모전</string>
+    <string name="home_tab_channel">채널</string>
+    <string name="home_tab_community">커뮤니티</string>
+
+    <!-- TapBar -->
+    <string name="newbie_tab_home">홈</string>
+    <string name="newbie_tab_intern">인턴</string>
+    <string name="newbie_tab_newbie">신입</string>
+    <string name="newbie_tab_calendar">공고달력</string>
+    <string name="newbie_tab_arrow_down_contentDescription">메뉴 탭 전체보기</string>
+
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #21

## Work Description ✏️
- 홈 화면 탭바 (신입/인턴 탭만 클릭됨)
- 인턴 화면 탭바

## Screenshot 📸
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
</head>
<body>
    <h1>탭바 상태 비교</h1>
    <table>
        <thead>
            <tr>
                <th>화면 타입</th>
                <th>이미지</th>
                <th>설명</th>
            </tr>
        </thead>
        <tbody>
            <tr>
                <td>홈 화면 탭바 (선택)</td>
                <td><img src="https://github.com/user-attachments/assets/d393b67f-1705-4baa-b6d5-422b8521943a" alt="홈 화면 탭바 (선택)"></td>
                <td>"홈" 탭이 선택된 상태</td>
            </tr>
            <tr>
                <td>홈 화면 탭바 (미 선택)</td>
                <td><img src="https://github.com/user-attachments/assets/f582ca86-8a79-4676-a003-755c3d2b4b4e" alt="홈 화면 탭바 (미 선택)"></td>
                <td>아무 탭도 선택되지 않은 상태</td>
            </tr>
            <tr>
                <td>인턴 화면 탭바</td>
                <td><img src="https://github.com/user-attachments/assets/78a808f8-db2e-447f-9369-4425afbaf3e6" alt="인턴 화면 탭바"></td>
                <td>"인턴" 화면에 표시되는 탭바</td>
            </tr>
        </tbody>
    </table>
</body>
</html>

## To Reviewers 📢
- 프리뷰 함수로 볼 때 남는 공간이 많은데 프리뷰 함수라 그런건지, 그냥 남는건지 잘 모르겠네요..
- 인턴 화면은 항상 홈이 파란색 글자로 색칠 되어있게 만들었고 따로 클릭 이벤트는 만들지 않았습니다.
- 사진은 배경색이 적용이 안되었네요. (배경색 흰색으로 설정했습니다)
