### PR TITLE
[FEAT/#19] Footer 구현

### DIFF
--- a/app/src/main/java/org/sopt/linkareer/core/designsystem/component/footer/MainFooter.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/designsystem/component/footer/MainFooter.kt
@@ -1,0 +1,85 @@
+package org.sopt.linkareer.core.designsystem.component.footer
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.linkareer.R
+import org.sopt.linkareer.core.designsystem.theme.Black
+import org.sopt.linkareer.core.designsystem.theme.Gray400
+import org.sopt.linkareer.core.designsystem.theme.LINKareerAndroidTheme
+import org.sopt.linkareer.core.designsystem.theme.LINKareerTheme
+
+@Composable
+fun MainFooter(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier =
+            modifier
+                .fillMaxWidth(),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(68.dp),
+            modifier =
+                Modifier
+                    .padding(top = 9.dp),
+        ) {
+            FooterText(text = stringResource(R.string.footer_terms_of_use))
+            FooterText(text = stringResource(R.string.footer_personal_information_policy))
+            FooterText(text = stringResource(R.string.footer_customer_inquiry))
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier =
+                Modifier
+                    .padding(top = 8.dp, bottom = 27.dp),
+        ) {
+            Text(
+                stringResource(R.string.footer_copyright_1),
+                style = LINKareerTheme.typography.body13R11,
+                color = Gray400,
+            )
+            Text(
+                stringResource(R.string.footer_copyright_2),
+                style = LINKareerTheme.typography.label1B11,
+                color = Gray400,
+            )
+            Text(
+                stringResource(R.string.footer_copyright_3),
+                style = LINKareerTheme.typography.body13R11,
+                color = Gray400,
+            )
+        }
+    }
+}
+
+@Composable
+fun FooterText(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = LINKareerTheme.typography.label3M11,
+        color = Black,
+        modifier = modifier,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MainFooterPreview() {
+    LINKareerAndroidTheme {
+        MainFooter()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,13 @@
     <!-- component -->
     <string name="d_day">D - %s</string>
     <string name="chatting_home_refresh">다른 채팅방 보기</string>
+    <string name="footer_terms_of_use">이용약관</string>
+    <string name="footer_personal_information_policy">개인정보처리방침</string>
+    <string name="footer_customer_inquiry">고객문의</string>
+    <string name="footer_copyright_1">Copyright&#169;</string>
+    <string name="footer_copyright_2">Linkareer Inc.</string>
+    <string name="footer_copyright_3">All Rights Reserved</string>
+
 
     <!-- chatting -->
     <string name="chatting_textfield_hint">메세지 입력</string>


### PR DESCRIPTION
## Related issue 🛠
- closed #19 

## Work Description ✏️
- 홈, 인턴/신입 화면에서 사용되는 footer 구현

## Screenshot 📸
<img src="https://github.com/user-attachments/assets/d35bad65-ccc5-42f2-91c4-be2ddb86d49d" width="360"/>

## Uncompleted Tasks 😅
- 없습니다!

## To Reviewers 📢
- footer도 끝!!!