### PR TITLE
[Feat/#24] certification screen

### DIFF
--- a/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationAddImageView.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationAddImageView.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,7 +29,7 @@ import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 fun CertificationAddImageView(
     @DrawableRes addImage: Int?,
     onAddImageClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val isClicked = remember { mutableStateOf(false) }
 

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationAddImageView.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationAddImageView.kt
@@ -30,14 +30,14 @@ import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 fun CertificationAddImageView(
     @DrawableRes addImage: Int?,
     onAddImageClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val isClicked = remember { mutableStateOf(false) }
 
     Box(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
-                .height(160.dp)
                 .clickable {
                     isClicked.value = true
                     onAddImageClick()

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationConfirmButton.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationConfirmButton.kt
@@ -27,7 +27,7 @@ fun CertificationConfirmButton(
 ) {
     Button(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth(),
         contentPadding = PaddingValues(horizontal = 10.dp, vertical = 12.dp),
         onClick = { onClickButton() },

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationGuideList.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationGuideList.kt
@@ -30,7 +30,7 @@ import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 
 @Composable
 fun CertificationGuideList(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier =

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationGuideList.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationGuideList.kt
@@ -29,10 +29,12 @@ import org.sopt.linkareer.core.designsystem.theme.Gray900
 import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 
 @Composable
-fun CertificationGuideList() {
+fun CertificationGuideList(
+    modifier: Modifier = Modifier
+) {
     Column(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationTopBar.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationTopBar.kt
@@ -19,7 +19,7 @@ import org.sopt.linkareer.core.designsystem.theme.LINKareerAndroidTheme
 @Composable
 fun CertificationTopBar(
     onIconClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationTopBar.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationTopBar.kt
@@ -19,12 +19,13 @@ import org.sopt.linkareer.core.designsystem.theme.LINKareerAndroidTheme
 @Composable
 fun CertificationTopBar(
     onIconClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth(),
     ) {
         Icon(

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationCheckSuccessScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationCheckSuccessScreen.kt
@@ -1,0 +1,82 @@
+package org.sopt.linkareer.feature.certification.navigation
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.linkareer.R
+import org.sopt.linkareer.core.designsystem.theme.Gray700
+import org.sopt.linkareer.core.designsystem.theme.Gray900
+import org.sopt.linkareer.core.designsystem.theme.LINKareerAndroidTheme
+import org.sopt.linkareer.core.designsystem.theme.White
+import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
+import org.sopt.linkareer.feature.certification.component.CertificationConfirmButton
+import org.sopt.linkareer.feature.certification.component.CertificationTopBar
+
+@Composable
+fun CertificationCheckSuccessRoute() {
+
+}
+
+@Composable
+fun CertificationCheckSuccessScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(White)
+    ) {
+        CertificationTopBar(
+            onIconClick = {}, // 클릭 시 뒤로가기 수행
+            modifier = Modifier
+                .padding(top = 27.dp)
+        )
+        Text(
+            text = stringResource(R.string.certification_check_title),
+            style = defaultLINKareerTypography.title3B16,
+            color = Gray900,
+            modifier = Modifier
+                .padding(start = 17.dp, top = 16.dp)
+        )
+        Text(
+            text = stringResource(R.string.certification_check_subtitle),
+            style = defaultLINKareerTypography.body10M11,
+            color = Gray700,
+            modifier = Modifier
+                .padding(start = 17.dp, top = 8.dp)
+        )
+        Image(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_check_circle_144),
+            contentDescription = stringResource(R.string.certification_check_success),
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(top = 147.dp)
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        CertificationConfirmButton(
+            buttonText = R.string.certification_confirm_button,
+            onClickButton = {},
+            modifier = Modifier
+                .padding(horizontal = 17.dp)
+                .padding(bottom = 32.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CertificationCheckSuccessScreenPreview() {
+    LINKareerAndroidTheme {
+        CertificationCheckSuccessScreen()
+    }
+}

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationCheckSuccessScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationCheckSuccessScreen.kt
@@ -26,49 +26,54 @@ import org.sopt.linkareer.feature.certification.component.CertificationTopBar
 
 @Composable
 fun CertificationCheckSuccessRoute() {
-
 }
 
 @Composable
 fun CertificationCheckSuccessScreen() {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(White)
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(White),
     ) {
         CertificationTopBar(
-            onIconClick = {}, // 클릭 시 뒤로가기 수행
-            modifier = Modifier
-                .padding(top = 27.dp)
+            onIconClick = {},
+            modifier =
+                Modifier
+                    .padding(top = 27.dp),
         )
         Text(
             text = stringResource(R.string.certification_check_title),
             style = defaultLINKareerTypography.title3B16,
             color = Gray900,
-            modifier = Modifier
-                .padding(start = 17.dp, top = 16.dp)
+            modifier =
+                Modifier
+                    .padding(start = 17.dp, top = 16.dp),
         )
         Text(
             text = stringResource(R.string.certification_check_subtitle),
             style = defaultLINKareerTypography.body10M11,
             color = Gray700,
-            modifier = Modifier
-                .padding(start = 17.dp, top = 8.dp)
+            modifier =
+                Modifier
+                    .padding(start = 17.dp, top = 8.dp),
         )
         Image(
             imageVector = ImageVector.vectorResource(R.drawable.ic_check_circle_144),
             contentDescription = stringResource(R.string.certification_check_success),
-            modifier = Modifier
-                .align(Alignment.CenterHorizontally)
-                .padding(top = 147.dp)
+            modifier =
+                Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 147.dp),
         )
         Spacer(modifier = Modifier.weight(1f))
         CertificationConfirmButton(
             buttonText = R.string.certification_confirm_button,
             onClickButton = {},
-            modifier = Modifier
-                .padding(horizontal = 17.dp)
-                .padding(bottom = 32.dp)
+            modifier =
+                Modifier
+                    .padding(horizontal = 17.dp)
+                    .padding(bottom = 32.dp),
         )
     }
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationEnterInformationRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationEnterInformationRoute.kt
@@ -30,89 +30,100 @@ fun CertificationEnterInformationRoute() {
 @Composable
 fun CertificationEnterInformationScreen() {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(White)
-    ){
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(White),
+    ) {
         CertificationTopBar(
-            onIconClick = {}, // 클릭 시 뒤로가기 수행
-            modifier = Modifier
-                .padding(top = 27.dp)
+            onIconClick = {},
+            modifier =
+                Modifier
+                    .padding(top = 27.dp),
         )
         Text(
             text = stringResource(R.string.certification_write_title),
             style = defaultLINKareerTypography.title3B16,
             color = Gray900,
-            modifier = Modifier
-                .padding(start = 17.dp, top = 16.dp)
+            modifier =
+                Modifier
+                    .padding(start = 17.dp, top = 16.dp),
         )
 
         Text(
             text = stringResource(R.string.certification_name_field),
             style = defaultLINKareerTypography.body4B12,
             color = Gray900,
-            modifier = Modifier
-                .padding(start = 17.dp, top = 32.dp)
+            modifier =
+                Modifier
+                    .padding(start = 17.dp, top = 32.dp),
         )
         CertificationTextField(
             value = "",
             onValueChange = {},
             hintText = stringResource(R.string.certification_name_placeholder),
-            helperMessage = "", // 무엇을 의미하는지 모르겟음
-            showHelperMessage = false, // 무엇을 의미하는지 모르겟음
-            modifier = Modifier
-                .padding(horizontal = 17.dp)
-                .padding(top = 12.dp)
+            helperMessage = "",
+            showHelperMessage = false,
+            modifier =
+                Modifier
+                    .padding(horizontal = 17.dp)
+                    .padding(top = 12.dp),
         )
 
         Text(
             text = stringResource(R.string.certification_phone_field),
             style = defaultLINKareerTypography.body4B12,
             color = Gray900,
-            modifier = Modifier
-                .padding(start = 17.dp, top = 32.dp)
+            modifier =
+                Modifier
+                    .padding(start = 17.dp, top = 32.dp),
         )
         CertificationTextField(
             value = "",
             onValueChange = {},
             hintText = stringResource(R.string.certification_phone_placeholder),
-            helperMessage = "", // 무엇을 의미하는지 모르겟음
+            helperMessage = "",
             showHelperMessage = false,
-            modifier = Modifier
-                .padding(horizontal = 17.dp)
-                .padding(top = 12.dp)
+            modifier =
+                Modifier
+                    .padding(horizontal = 17.dp)
+                    .padding(top = 12.dp),
         )
 
         Text(
             text = stringResource(R.string.certification_capture_field),
             style = defaultLINKareerTypography.body4B12,
             color = Gray900,
-            modifier = Modifier
-                .padding(horizontal = 17.dp)
-                .padding(top = 32.dp)
+            modifier =
+                Modifier
+                    .padding(horizontal = 17.dp)
+                    .padding(top = 32.dp),
         )
         Text(
             text = stringResource(R.string.certification_write_capture_desc),
             style = defaultLINKareerTypography.label4M10,
             color = Gray600,
-            modifier = Modifier
-                .padding(horizontal = 17.dp)
-                .padding(top = 4.dp)
+            modifier =
+                Modifier
+                    .padding(horizontal = 17.dp)
+                    .padding(top = 4.dp),
         )
         CertificationAddImageView(
             addImage = R.drawable.img_chatting_validation,
-            onAddImageClick = {}, // 클릭시 이미지 addImage로 변경
-            modifier = Modifier
-                .padding(top = 12.dp)
+            onAddImageClick = {},
+            modifier =
+                Modifier
+                    .padding(top = 12.dp),
         )
 
         Spacer(modifier = Modifier.weight(1f))
         CertificationConfirmButton(
             buttonText = R.string.certification_confirm_button,
             onClickButton = {},
-            modifier = Modifier
-                .padding(horizontal = 17.dp)
-                .padding(bottom = 32.dp)
+            modifier =
+                Modifier
+                    .padding(horizontal = 17.dp)
+                    .padding(bottom = 32.dp),
         )
     }
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationEnterInformationRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationEnterInformationRoute.kt
@@ -1,0 +1,126 @@
+package org.sopt.linkareer.feature.certification.navigation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.linkareer.R
+import org.sopt.linkareer.core.designsystem.component.textfield.CertificationTextField
+import org.sopt.linkareer.core.designsystem.theme.Gray600
+import org.sopt.linkareer.core.designsystem.theme.Gray900
+import org.sopt.linkareer.core.designsystem.theme.LINKareerAndroidTheme
+import org.sopt.linkareer.core.designsystem.theme.White
+import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
+import org.sopt.linkareer.feature.certification.component.CertificationAddImageView
+import org.sopt.linkareer.feature.certification.component.CertificationConfirmButton
+import org.sopt.linkareer.feature.certification.component.CertificationTopBar
+
+@Composable
+fun CertificationEnterInformationRoute() {
+    CertificationEnterInformationScreen()
+}
+
+@Composable
+fun CertificationEnterInformationScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(White)
+    ){
+        CertificationTopBar(
+            onIconClick = {}, // 클릭 시 뒤로가기 수행
+            modifier = Modifier
+                .padding(top = 27.dp)
+        )
+        Text(
+            text = stringResource(R.string.certification_write_title),
+            style = defaultLINKareerTypography.title3B16,
+            color = Gray900,
+            modifier = Modifier
+                .padding(start = 17.dp, top = 16.dp)
+        )
+
+        Text(
+            text = stringResource(R.string.certification_name_field),
+            style = defaultLINKareerTypography.body4B12,
+            color = Gray900,
+            modifier = Modifier
+                .padding(start = 17.dp, top = 32.dp)
+        )
+        CertificationTextField(
+            value = "",
+            onValueChange = {},
+            hintText = stringResource(R.string.certification_name_placeholder),
+            helperMessage = "", // 무엇을 의미하는지 모르겟음
+            showHelperMessage = false, // 무엇을 의미하는지 모르겟음
+            modifier = Modifier
+                .padding(horizontal = 17.dp)
+                .padding(top = 12.dp)
+        )
+
+        Text(
+            text = stringResource(R.string.certification_phone_field),
+            style = defaultLINKareerTypography.body4B12,
+            color = Gray900,
+            modifier = Modifier
+                .padding(start = 17.dp, top = 32.dp)
+        )
+        CertificationTextField(
+            value = "",
+            onValueChange = {},
+            hintText = stringResource(R.string.certification_phone_placeholder),
+            helperMessage = "", // 무엇을 의미하는지 모르겟음
+            showHelperMessage = false,
+            modifier = Modifier
+                .padding(horizontal = 17.dp)
+                .padding(top = 12.dp)
+        )
+
+        Text(
+            text = stringResource(R.string.certification_capture_field),
+            style = defaultLINKareerTypography.body4B12,
+            color = Gray900,
+            modifier = Modifier
+                .padding(horizontal = 17.dp)
+                .padding(top = 32.dp)
+        )
+        Text(
+            text = stringResource(R.string.certification_write_capture_desc),
+            style = defaultLINKareerTypography.label4M10,
+            color = Gray600,
+            modifier = Modifier
+                .padding(horizontal = 17.dp)
+                .padding(top = 4.dp)
+        )
+        CertificationAddImageView(
+            addImage = R.drawable.img_chatting_validation,
+            onAddImageClick = {}, // 클릭시 이미지 addImage로 변경
+            modifier = Modifier
+                .padding(top = 12.dp)
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+        CertificationConfirmButton(
+            buttonText = R.string.certification_confirm_button,
+            onClickButton = {},
+            modifier = Modifier
+                .padding(horizontal = 17.dp)
+                .padding(bottom = 32.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CertificationEnterInformationScreenPreview() {
+    LINKareerAndroidTheme {
+        CertificationEnterInformationScreen()
+    }
+}

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationGuideRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationGuideRoute.kt
@@ -27,34 +27,39 @@ fun CertificationGuideRoute() {
 @Composable
 fun CertificationGuideScreen() {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(White)
-    ){
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(White),
+    ) {
         CertificationTopBar(
-            onIconClick = {}, // 클릭 시 뒤로가기 수행
-            modifier = Modifier
-                .padding(top = 27.dp)
+            onIconClick = {},
+            modifier =
+                Modifier
+                    .padding(top = 27.dp),
         )
         Text(
             text = stringResource(R.string.certification_guide_title),
             style = defaultLINKareerTypography.title3B16,
             color = Gray900,
-            modifier = Modifier
-                .padding(start = 17.dp, top = 16.dp)
+            modifier =
+                Modifier
+                    .padding(start = 17.dp, top = 16.dp),
         )
         CertificationGuideList(
-            modifier = Modifier
-                .padding(horizontal = 17.dp)
-                .padding(top = 32.dp)
+            modifier =
+                Modifier
+                    .padding(horizontal = 17.dp)
+                    .padding(top = 32.dp),
         )
         Spacer(modifier = Modifier.weight(1f))
         CertificationConfirmButton(
             buttonText = R.string.certification_ok_button,
             onClickButton = {},
-            modifier = Modifier
-                .padding(horizontal = 17.dp)
-                .padding(bottom = 32.dp)
+            modifier =
+                Modifier
+                    .padding(horizontal = 17.dp)
+                    .padding(bottom = 32.dp),
         )
     }
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationGuideRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationGuideRoute.kt
@@ -1,0 +1,66 @@
+package org.sopt.linkareer.feature.certification.navigation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.linkareer.R
+import org.sopt.linkareer.core.designsystem.theme.Gray900
+import org.sopt.linkareer.core.designsystem.theme.White
+import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
+import org.sopt.linkareer.feature.certification.component.CertificationConfirmButton
+import org.sopt.linkareer.feature.certification.component.CertificationGuideList
+import org.sopt.linkareer.feature.certification.component.CertificationTopBar
+
+@Composable
+fun CertificationGuideRoute() {
+    CertificationGuideScreen()
+}
+
+@Composable
+fun CertificationGuideScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(White)
+    ){
+        CertificationTopBar(
+            onIconClick = {}, // 클릭 시 뒤로가기 수행
+            modifier = Modifier
+                .padding(top = 27.dp)
+        )
+        Text(
+            text = stringResource(R.string.certification_guide_title),
+            style = defaultLINKareerTypography.title3B16,
+            color = Gray900,
+            modifier = Modifier
+                .padding(start = 17.dp, top = 16.dp)
+        )
+        CertificationGuideList(
+            modifier = Modifier
+                .padding(horizontal = 17.dp)
+                .padding(top = 32.dp)
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        CertificationConfirmButton(
+            buttonText = R.string.certification_ok_button,
+            onClickButton = {},
+            modifier = Modifier
+                .padding(horizontal = 17.dp)
+                .padding(bottom = 32.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CertificationGuideScreenPreview() {
+    CertificationGuideScreen()
+}

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationRoute.kt
@@ -1,4 +1,0 @@
-package org.sopt.linkareer.feature.certification.navigation
-
-// 임시 파일
-class CertificationRoute


### PR DESCRIPTION
## Related issue 🛠
- closed #24

## Work Description ✏️
- 인증 화면1 (조건 설명)
- 인증 화면2 (인증 정보 입력)
- 인증 성공 화면

## Screenshot 📸
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
</head>
<body>
    <h1>인증 화면 UI</h1>
    <table>
        <thead>
            <tr>
                <th>구현 화면</th>
                <th>이미지</th>
            </tr>
        </thead>
        <tbody>
            <tr>
                <td>인증 화면1 (인증 정보 설명)</td>
                <td><img src="https://github.com/user-attachments/assets/f50753e2-1af4-449a-a1c7-abd848b6f944" alt=""></td>
            </tr>
            <tr>
                <td>인증 화면2 (인증 정보 입력)</td>
                <td><img src="https://github.com/user-attachments/assets/a8c2e22a-f7b4-4cd4-8b7c-d66786d31a10" alt=""></td>
            </tr>
            <tr>
                <td>인증 성공 화면</td>
                <td><img src="https://github.com/user-attachments/assets/239d17e5-4e60-407e-b620-638cebc81e7f" alt=""></td>
            </tr>
        </tbody>
    </table>
</body>
</html>

## To Reviewers 📢
추가해야 할 것
- 텍스트 필드에 테두리(border) 없는 것 (인증 정보 입력 화면)
- 버튼 활성화/비활성화
- 상단 바 뒤로가기 버튼시 클릭시 뒤로가기
- 캡쳐본 이미지 클릭하면 다른 이미지로 변경되게하기 
- 확인/완료 버튼 클릭하면 다음 화면으로 이동 (네비게이션)