### PR TITLE
[Feat/#26] 채팅방 UI 구현

### DIFF
--- a/app/src/main/java/org/sopt/linkareer/feature/chatting/ChattingRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/chatting/ChattingRoute.kt
@@ -42,14 +42,15 @@ fun ChattingScreen(
         BackChattingRoomTopAppBar(
             chattingRoomName = "현대자동차",
             chattingRoomHeadCount = 1294,
-            onBackButtonClick = {}
+            onBackButtonClick = {},
         )
         ChatRoomTopNotice()
 
 //        // 채팅 방
-        LazyColumn (
-            modifier = Modifier
-                .background(White)
+        LazyColumn(
+            modifier =
+                Modifier
+                    .background(White),
         ) {
             // 채팅쪽은 서버 구현하면서 만들어야 함
             item {
@@ -59,7 +60,7 @@ fun ChattingScreen(
                     jobCategory = "현대 자동차",
                     imageUrl = "",
                     sendMessage = "안녕하세요 만나서 반가워요",
-                    timestamp = "00:00"
+                    timestamp = "00:00",
                 )
             }
             item {
@@ -71,36 +72,39 @@ fun ChattingScreen(
                     sender = "검은색 고양이",
                     receivedMessage = "반갑습니다. 고양이 보은",
                     replyMessage = "안녕하세요 저도 만나서 반가워요",
-                    timestamp = "00:00"
+                    timestamp = "00:00",
                 )
             }
         }
         ChatRoomBottomNotice(
             onClickDelete = {},
             onClickToCheck = {},
-            modifier = Modifier
-                .padding(horizontal = 18.dp)
-                .padding(bottom = 1.dp)
+            modifier =
+                Modifier
+                    .padding(horizontal = 18.dp)
+                    .padding(bottom = 1.dp),
         )
         Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(White)
-                .drawBehind {
-                    drawLine(
-                        color = Gray300,
-                        start = Offset(0f, 0f),
-                        end = Offset(size.width, 0f),
-                        strokeWidth = 1.dp.toPx(),
-                    )
-                }
-                .padding(vertical = 12.dp, horizontal = 18.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .background(White)
+                    .drawBehind {
+                        drawLine(
+                            color = Gray300,
+                            start = Offset(0f, 0f),
+                            end = Offset(size.width, 0f),
+                            strokeWidth = 1.dp.toPx(),
+                        )
+                    }
+                    .padding(vertical = 12.dp, horizontal = 18.dp),
         ) {
             ChattingTextField(
                 value = "",
-                onValueChange ={} ,
-                modifier = Modifier
-                    .padding(horizontal = 18.dp, vertical = 12.dp),
+                onValueChange = {},
+                modifier =
+                    Modifier
+                        .padding(horizontal = 18.dp, vertical = 12.dp),
             )
         }
     }
@@ -110,6 +114,6 @@ fun ChattingScreen(
 @Composable
 fun ChattingScreenPreview() {
     ChattingScreen(
-        paddingValues = PaddingValues(vertical = 8.dp)
+        paddingValues = PaddingValues(vertical = 8.dp),
     )
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/chatting/ChattingRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/chatting/ChattingRoute.kt
@@ -1,11 +1,26 @@
 package org.sopt.linkareer.feature.chatting
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.linkareer.core.designsystem.component.textfield.ChattingTextField
+import org.sopt.linkareer.core.designsystem.component.topappbar.BackChattingRoomTopAppBar
+import org.sopt.linkareer.core.designsystem.theme.Gray300
+import org.sopt.linkareer.core.designsystem.theme.White
+import org.sopt.linkareer.feature.chatting.component.ChatRoomBottomNotice
+import org.sopt.linkareer.feature.chatting.component.ChatRoomTopNotice
+import org.sopt.linkareer.feature.chatting.component.OtherUserChat
+import org.sopt.linkareer.feature.chatting.component.OtherUserReplyChat
 
 @Composable
 fun ChattingRoute(
@@ -21,8 +36,80 @@ fun ChattingScreen(
     Column(
         modifier =
             Modifier
-                .padding(paddingValues),
+                .padding(paddingValues)
+                .background(White),
     ) {
-        Text("Chatting")
+        BackChattingRoomTopAppBar(
+            chattingRoomName = "현대자동차",
+            chattingRoomHeadCount = 1294,
+            onBackButtonClick = {}
+        )
+        ChatRoomTopNotice()
+
+//        // 채팅 방
+        LazyColumn (
+            modifier = Modifier
+                .background(White)
+        ) {
+            // 채팅쪽은 서버 구현하면서 만들어야 함
+            item {
+                OtherUserChat(
+                    nickName = "검은색 고양이",
+                    isChecked = true,
+                    jobCategory = "현대 자동차",
+                    imageUrl = "",
+                    sendMessage = "안녕하세요 만나서 반가워요",
+                    timestamp = "00:00"
+                )
+            }
+            item {
+                OtherUserReplyChat(
+                    nickName = "연두색 물고기",
+                    isChecked = false,
+                    jobCategory = "올리브영",
+                    imageUrl = "",
+                    sender = "검은색 고양이",
+                    receivedMessage = "반갑습니다. 고양이 보은",
+                    replyMessage = "안녕하세요 저도 만나서 반가워요",
+                    timestamp = "00:00"
+                )
+            }
+        }
+        ChatRoomBottomNotice(
+            onClickDelete = {},
+            onClickToCheck = {},
+            modifier = Modifier
+                .padding(horizontal = 18.dp)
+                .padding(bottom = 1.dp)
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(White)
+                .drawBehind {
+                    drawLine(
+                        color = Gray300,
+                        start = Offset(0f, 0f),
+                        end = Offset(size.width, 0f),
+                        strokeWidth = 1.dp.toPx(),
+                    )
+                }
+                .padding(vertical = 12.dp, horizontal = 18.dp),
+        ) {
+            ChattingTextField(
+                value = "",
+                onValueChange ={} ,
+                modifier = Modifier
+                    .padding(horizontal = 18.dp, vertical = 12.dp),
+            )
+        }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ChattingScreenPreview() {
+    ChattingScreen(
+        paddingValues = PaddingValues(vertical = 8.dp)
+    )
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/chatting/component/ChatRoomBottomNotice.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/chatting/component/ChatRoomBottomNotice.kt
@@ -32,10 +32,11 @@ import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 fun ChatRoomBottomNotice(
     onClickToCheck: () -> Unit,
     onClickDelete: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Box(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(10.dp))
                 .background(Gray100)

--- a/app/src/main/java/org/sopt/linkareer/feature/chatting/component/ChatRoomBottomNotice.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/chatting/component/ChatRoomBottomNotice.kt
@@ -32,7 +32,7 @@ import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 fun ChatRoomBottomNotice(
     onClickToCheck: () -> Unit,
     onClickDelete: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Box(
         modifier =


### PR DESCRIPTION
## Related issue 🛠
- closed #26

## Work Description ✏️
- 채팅방 UI 구현

## Screenshot 📸
<img src="https://github.com/user-attachments/assets/8d061c49-af68-4e8c-8bc6-9b0a296aaa6b" width="360"/>
<img src="https://github.com/user-attachments/assets/67d84348-0892-40e5-8173-cf36c309dc0b" width="360"/>

## To Reviewers 📢
- TextField Border 수정한 풀리퀘스트 코드 합쳐지면 TextField Border 설정해야 합니다.
- 서버통신 하지 않고 바로 채팅 구현 하는건 어려워서 임시로 수동으로 더미데이터 넣어뒀습니다.
    - 서버통신 하면서 진행해야 할 것 같습니다.
- 왜인지는 모르겠는데 TextField 아래에 추가된? 공간이 더 보이는데 뭔지 모르겠습니다. (두 번째 사진)