### PR TITLE
[Feat/#45] 인증 화면 네비게이션 구현

### DIFF
--- a/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/HomeTapBar.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/HomeTapBar.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -44,17 +43,17 @@ fun HomeTapBar(
 
     Row(
         modifier =
-        modifier
-            .fillMaxWidth()
-            .background(White)
-            .padding(start = 11.dp),
+            modifier
+                .fillMaxWidth()
+                .background(White)
+                .padding(start = 11.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         LazyRow(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             modifier =
-            Modifier
-                .weight(1f),
+                Modifier
+                    .weight(1f),
         ) {
             item {
                 TabItem(
@@ -74,7 +73,7 @@ fun HomeTapBar(
                     onClick = {
                         rememberTap = contestTab
                         onTabClick(contestTab)
-                    }
+                    },
                 )
             }
             item {
@@ -85,7 +84,7 @@ fun HomeTapBar(
                     onClick = {
                         rememberTap = channelTab
                         onTabClick(channelTab)
-                    }
+                    },
                 )
             }
             item {
@@ -96,7 +95,7 @@ fun HomeTapBar(
                     onClick = {
                         rememberTap = communityTab
                         onTabClick(communityTab)
-                    }
+                    },
                 )
             }
         }
@@ -104,8 +103,8 @@ fun HomeTapBar(
             imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_down_box_30),
             contentDescription = stringResource(R.string.newbie_tab_arrow_down_contentDescription),
             modifier =
-            Modifier
-                .padding(start = 8.dp, end = 10.dp),
+                Modifier
+                    .padding(start = 8.dp, end = 10.dp),
         )
     }
 }

--- a/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/HomeTapBar.kt
+++ b/app/src/main/java/org/sopt/linkareer/core/designsystem/component/tapbar/HomeTapBar.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -43,51 +44,68 @@ fun HomeTapBar(
 
     Row(
         modifier =
-            modifier
-                .fillMaxWidth()
-                .background(White)
-                .padding(start = 11.dp),
+        modifier
+            .fillMaxWidth()
+            .background(White)
+            .padding(start = 11.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
             modifier =
-                Modifier
-                    .weight(1f),
+            Modifier
+                .weight(1f),
         ) {
-            TabItem(
-                tapName = newbieTab,
-                isSelected = rememberTap == newbieTab,
-                onClick = {
-                    rememberTap = newbieTab
-                    onTabClick(newbieTab)
-                },
-            )
-            Spacer(modifier = Modifier.padding(start = 12.dp))
-
-            TabItem(
-                tapName = stringResource(R.string.home_tab_contest),
-                isSelected = false,
-            )
-            Spacer(modifier = Modifier.padding(start = 12.dp))
-
-            TabItem(
-                tapName = stringResource(R.string.home_tab_channel),
-                isSelected = false,
-            )
-            Spacer(modifier = Modifier.padding(start = 12.dp))
-
-            TabItem(
-                tapName = stringResource(R.string.home_tab_community),
-                isSelected = false,
-            )
+            item {
+                TabItem(
+                    tapName = newbieTab,
+                    isSelected = rememberTap == newbieTab,
+                    onClick = {
+                        rememberTap = newbieTab
+                        onTabClick(newbieTab)
+                    },
+                )
+            }
+            item {
+                val contestTab = stringResource(R.string.home_tab_contest)
+                TabItem(
+                    tapName = contestTab,
+                    isSelected = rememberTap == contestTab,
+                    onClick = {
+                        rememberTap = contestTab
+                        onTabClick(contestTab)
+                    }
+                )
+            }
+            item {
+                val channelTab = stringResource(R.string.home_tab_channel)
+                TabItem(
+                    tapName = channelTab,
+                    isSelected = rememberTap == channelTab,
+                    onClick = {
+                        rememberTap = channelTab
+                        onTabClick(channelTab)
+                    }
+                )
+            }
+            item {
+                val communityTab = stringResource(R.string.home_tab_community)
+                TabItem(
+                    tapName = communityTab,
+                    isSelected = rememberTap == communityTab,
+                    onClick = {
+                        rememberTap = communityTab
+                        onTabClick(communityTab)
+                    }
+                )
+            }
         }
         Image(
             imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_down_box_30),
             contentDescription = stringResource(R.string.newbie_tab_arrow_down_contentDescription),
             modifier =
-                Modifier
-                    .padding(start = 8.dp, end = 10.dp),
+            Modifier
+                .padding(start = 8.dp, end = 10.dp),
         )
     }
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationCheckSuccessScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationCheckSuccessScreen.kt
@@ -1,5 +1,6 @@
-package org.sopt.linkareer.feature.certification.navigation
+package org.sopt.linkareer.feature.certification
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -7,25 +8,28 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.linkareer.R
+import org.sopt.linkareer.core.designsystem.theme.Gray700
 import org.sopt.linkareer.core.designsystem.theme.Gray900
+import org.sopt.linkareer.core.designsystem.theme.LINKareerAndroidTheme
 import org.sopt.linkareer.core.designsystem.theme.White
 import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 import org.sopt.linkareer.feature.certification.component.CertificationConfirmButton
-import org.sopt.linkareer.feature.certification.component.CertificationGuideList
 import org.sopt.linkareer.feature.certification.component.CertificationTopBar
 
 @Composable
-fun CertificationGuideRoute() {
-    CertificationGuideScreen()
+fun CertificationCheckSuccessRoute() {
 }
 
 @Composable
-fun CertificationGuideScreen() {
+fun CertificationCheckSuccessScreen() {
     Column(
         modifier =
             Modifier
@@ -39,22 +43,32 @@ fun CertificationGuideScreen() {
                     .padding(top = 27.dp),
         )
         Text(
-            text = stringResource(R.string.certification_guide_title),
+            text = stringResource(R.string.certification_check_title),
             style = defaultLINKareerTypography.title3B16,
             color = Gray900,
             modifier =
                 Modifier
                     .padding(start = 17.dp, top = 16.dp),
         )
-        CertificationGuideList(
+        Text(
+            text = stringResource(R.string.certification_check_subtitle),
+            style = defaultLINKareerTypography.body10M11,
+            color = Gray700,
             modifier =
                 Modifier
-                    .padding(horizontal = 17.dp)
-                    .padding(top = 32.dp),
+                    .padding(start = 17.dp, top = 8.dp),
+        )
+        Image(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_check_circle_144),
+            contentDescription = stringResource(R.string.certification_check_success),
+            modifier =
+                Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 147.dp),
         )
         Spacer(modifier = Modifier.weight(1f))
         CertificationConfirmButton(
-            buttonText = R.string.certification_ok_button,
+            buttonText = R.string.certification_confirm_button,
             onClickButton = {},
             modifier =
                 Modifier
@@ -66,6 +80,8 @@ fun CertificationGuideScreen() {
 
 @Preview(showBackground = true)
 @Composable
-fun CertificationGuideScreenPreview() {
-    CertificationGuideScreen()
+fun CertificationCheckSuccessScreenPreview() {
+    LINKareerAndroidTheme {
+        CertificationCheckSuccessScreen()
+    }
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationCheckSuccessScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationCheckSuccessScreen.kt
@@ -29,7 +29,7 @@ fun CertificationCheckSuccessRoute(
     navigateToChattingRoom: () -> Unit,
 ) {
     CertificationCheckSuccessScreen(
-        navigateToChattingRoom = navigateToChattingRoom
+        navigateToChattingRoom = navigateToChattingRoom,
     )
 }
 
@@ -91,7 +91,7 @@ fun CertificationCheckSuccessScreen(
 fun CertificationCheckSuccessScreenPreview() {
     LINKareerAndroidTheme {
         CertificationCheckSuccessScreen(
-            navigateToChattingRoom = {}
+            navigateToChattingRoom = {},
         )
     }
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationCheckSuccessScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationCheckSuccessScreen.kt
@@ -23,7 +23,6 @@ import org.sopt.linkareer.core.designsystem.theme.LINKareerTheme
 import org.sopt.linkareer.core.designsystem.theme.White
 import org.sopt.linkareer.feature.certification.component.CertificationConfirmButton
 import org.sopt.linkareer.feature.certification.component.CertificationTopBar
-import org.sopt.linkareer.feature.chattingroom.navigation.navigateToChattingRoom
 
 @Composable
 fun CertificationCheckSuccessRoute(

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationCheckSuccessScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationCheckSuccessScreen.kt
@@ -21,12 +21,12 @@ import org.sopt.linkareer.core.designsystem.theme.Gray900
 import org.sopt.linkareer.core.designsystem.theme.LINKareerAndroidTheme
 import org.sopt.linkareer.core.designsystem.theme.LINKareerTheme
 import org.sopt.linkareer.core.designsystem.theme.White
-import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 import org.sopt.linkareer.feature.certification.component.CertificationConfirmButton
 import org.sopt.linkareer.feature.certification.component.CertificationTopBar
 
 @Composable
 fun CertificationCheckSuccessRoute() {
+    CertificationCheckSuccessScreen()
 }
 
 @Composable

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationCheckSuccessScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationCheckSuccessScreen.kt
@@ -23,14 +23,21 @@ import org.sopt.linkareer.core.designsystem.theme.LINKareerTheme
 import org.sopt.linkareer.core.designsystem.theme.White
 import org.sopt.linkareer.feature.certification.component.CertificationConfirmButton
 import org.sopt.linkareer.feature.certification.component.CertificationTopBar
+import org.sopt.linkareer.feature.chattingroom.navigation.navigateToChattingRoom
 
 @Composable
-fun CertificationCheckSuccessRoute() {
-    CertificationCheckSuccessScreen()
+fun CertificationCheckSuccessRoute(
+    navigateToChattingRoom: () -> Unit,
+) {
+    CertificationCheckSuccessScreen(
+        navigateToChattingRoom = navigateToChattingRoom
+    )
 }
 
 @Composable
-fun CertificationCheckSuccessScreen() {
+fun CertificationCheckSuccessScreen(
+    navigateToChattingRoom: () -> Unit,
+) {
     Column(
         modifier =
             Modifier
@@ -70,7 +77,7 @@ fun CertificationCheckSuccessScreen() {
         Spacer(modifier = Modifier.weight(1f))
         CertificationConfirmButton(
             buttonText = R.string.certification_confirm_button,
-            onClickButton = {},
+            onClickButton = navigateToChattingRoom,
             isEnabled = true,
             modifier =
                 Modifier
@@ -84,6 +91,8 @@ fun CertificationCheckSuccessScreen() {
 @Composable
 fun CertificationCheckSuccessScreenPreview() {
     LINKareerAndroidTheme {
-        CertificationCheckSuccessScreen()
+        CertificationCheckSuccessScreen(
+            navigateToChattingRoom = {}
+        )
     }
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationCheckSuccessScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationCheckSuccessScreen.kt
@@ -19,6 +19,7 @@ import org.sopt.linkareer.R
 import org.sopt.linkareer.core.designsystem.theme.Gray700
 import org.sopt.linkareer.core.designsystem.theme.Gray900
 import org.sopt.linkareer.core.designsystem.theme.LINKareerAndroidTheme
+import org.sopt.linkareer.core.designsystem.theme.LINKareerTheme
 import org.sopt.linkareer.core.designsystem.theme.White
 import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 import org.sopt.linkareer.feature.certification.component.CertificationConfirmButton
@@ -44,7 +45,7 @@ fun CertificationCheckSuccessScreen() {
         )
         Text(
             text = stringResource(R.string.certification_check_title),
-            style = defaultLINKareerTypography.title3B16,
+            style = LINKareerTheme.typography.title3B16,
             color = Gray900,
             modifier =
                 Modifier
@@ -52,7 +53,7 @@ fun CertificationCheckSuccessScreen() {
         )
         Text(
             text = stringResource(R.string.certification_check_subtitle),
-            style = defaultLINKareerTypography.body10M11,
+            style = LINKareerTheme.typography.body10M11,
             color = Gray700,
             modifier =
                 Modifier
@@ -70,6 +71,7 @@ fun CertificationCheckSuccessScreen() {
         CertificationConfirmButton(
             buttonText = R.string.certification_confirm_button,
             onClickButton = {},
+            isEnabled = true,
             modifier =
                 Modifier
                     .padding(horizontal = 17.dp)

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationEnterInformationRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationEnterInformationRoute.kt
@@ -1,4 +1,4 @@
-package org.sopt.linkareer.feature.certification.navigation
+package org.sopt.linkareer.feature.certification
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationEnterInformationRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationEnterInformationRoute.kt
@@ -7,6 +7,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -16,6 +20,7 @@ import org.sopt.linkareer.core.designsystem.component.textfield.CertificationTex
 import org.sopt.linkareer.core.designsystem.theme.Gray600
 import org.sopt.linkareer.core.designsystem.theme.Gray900
 import org.sopt.linkareer.core.designsystem.theme.LINKareerAndroidTheme
+import org.sopt.linkareer.core.designsystem.theme.LINKareerTheme
 import org.sopt.linkareer.core.designsystem.theme.White
 import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 import org.sopt.linkareer.feature.certification.component.CertificationAddImageBox
@@ -29,6 +34,9 @@ fun CertificationEnterInformationRoute() {
 
 @Composable
 fun CertificationEnterInformationScreen() {
+    var nameField by remember { mutableStateOf("") }
+    var phoneField by remember { mutableStateOf("") }
+
     Column(
         modifier =
             Modifier
@@ -43,7 +51,7 @@ fun CertificationEnterInformationScreen() {
         )
         Text(
             text = stringResource(R.string.certification_write_title),
-            style = defaultLINKareerTypography.title3B16,
+            style = LINKareerTheme.typography.title3B16,
             color = Gray900,
             modifier =
                 Modifier
@@ -52,15 +60,15 @@ fun CertificationEnterInformationScreen() {
 
         Text(
             text = stringResource(R.string.certification_name_field),
-            style = defaultLINKareerTypography.body4B12,
+            style = LINKareerTheme.typography.body4B12,
             color = Gray900,
             modifier =
                 Modifier
                     .padding(start = 17.dp, top = 32.dp),
         )
         CertificationTextField(
-            value = "",
-            onValueChange = {},
+            value = nameField,
+            onValueChange = { nameField = it },
             hintText = stringResource(R.string.certification_name_placeholder),
             helperMessage = "",
             showHelperMessage = false,
@@ -72,15 +80,15 @@ fun CertificationEnterInformationScreen() {
 
         Text(
             text = stringResource(R.string.certification_phone_field),
-            style = defaultLINKareerTypography.body4B12,
+            style = LINKareerTheme.typography.body4B12,
             color = Gray900,
             modifier =
                 Modifier
                     .padding(start = 17.dp, top = 32.dp),
         )
         CertificationTextField(
-            value = "",
-            onValueChange = {},
+            value = phoneField,
+            onValueChange = { phoneField = it },
             hintText = stringResource(R.string.certification_phone_placeholder),
             helperMessage = "",
             showHelperMessage = false,
@@ -119,6 +127,7 @@ fun CertificationEnterInformationScreen() {
         CertificationConfirmButton(
             buttonText = R.string.certification_confirm_button,
             onClickButton = {},
+            isEnabled = if(nameField.isEmpty() || phoneField.isEmpty()) false else true,
             modifier =
                 Modifier
                     .padding(horizontal = 17.dp)

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationEnterInformationRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationEnterInformationRoute.kt
@@ -133,7 +133,7 @@ fun CertificationEnterInformationScreen(
         CertificationConfirmButton(
             buttonText = R.string.certification_confirm_button,
             onClickButton = navigateToCertificationEnterInformation,
-            isEnabled = if(nameField.isEmpty() || phoneField.isEmpty()) false else true,
+            isEnabled = if (nameField.isEmpty() || phoneField.isEmpty()) false else true,
             modifier =
                 Modifier
                     .padding(horizontal = 17.dp)
@@ -147,7 +147,7 @@ fun CertificationEnterInformationScreen(
 fun CertificationEnterInformationScreenPreview() {
     LINKareerAndroidTheme {
         CertificationEnterInformationScreen(
-            navigateToCertificationEnterInformation = { }
+            navigateToCertificationEnterInformation = { },
         )
     }
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationEnterInformationRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationEnterInformationRoute.kt
@@ -28,12 +28,18 @@ import org.sopt.linkareer.feature.certification.component.CertificationConfirmBu
 import org.sopt.linkareer.feature.certification.component.CertificationTopBar
 
 @Composable
-fun CertificationEnterInformationRoute() {
-    CertificationEnterInformationScreen()
+fun CertificationEnterInformationRoute(
+    navigateToCertificationEnterInformation: () -> Unit,
+) {
+    CertificationEnterInformationScreen(
+        navigateToCertificationEnterInformation = navigateToCertificationEnterInformation,
+    )
 }
 
 @Composable
-fun CertificationEnterInformationScreen() {
+fun CertificationEnterInformationScreen(
+    navigateToCertificationEnterInformation: () -> Unit,
+) {
     var nameField by remember { mutableStateOf("") }
     var phoneField by remember { mutableStateOf("") }
 
@@ -126,7 +132,7 @@ fun CertificationEnterInformationScreen() {
         Spacer(modifier = Modifier.weight(1f))
         CertificationConfirmButton(
             buttonText = R.string.certification_confirm_button,
-            onClickButton = {},
+            onClickButton = navigateToCertificationEnterInformation,
             isEnabled = if(nameField.isEmpty() || phoneField.isEmpty()) false else true,
             modifier =
                 Modifier
@@ -140,6 +146,8 @@ fun CertificationEnterInformationScreen() {
 @Composable
 fun CertificationEnterInformationScreenPreview() {
     LINKareerAndroidTheme {
-        CertificationEnterInformationScreen()
+        CertificationEnterInformationScreen(
+            navigateToCertificationEnterInformation = { }
+        )
     }
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationEnterInformationRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationEnterInformationRoute.kt
@@ -110,7 +110,6 @@ fun CertificationEnterInformationScreen() {
         )
         CertificationAddImageBox(
             addImage = R.drawable.img_chatting_validation,
-            onAddImageClick = {},
             modifier =
                 Modifier
                     .padding(top = 12.dp),

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationGuideRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationGuideRoute.kt
@@ -62,6 +62,7 @@ fun CertificationGuideScreen(
         CertificationConfirmButton(
             buttonText = R.string.certification_ok_button,
             onClickButton = navigateToCertificationEnterInformation,
+            isEnabled = true,
             modifier =
                 Modifier
                     .padding(horizontal = 17.dp)

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationGuideRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationGuideRoute.kt
@@ -21,16 +21,16 @@ import org.sopt.linkareer.feature.certification.component.CertificationTopBar
 
 @Composable
 fun CertificationGuideRoute(
-    navigateToCertificationEnterInformation: () -> Unit
+    navigateToCertificationEnterInformation: () -> Unit,
 ) {
     CertificationGuideScreen(
-        navigateToCertificationEnterInformation = navigateToCertificationEnterInformation
+        navigateToCertificationEnterInformation = navigateToCertificationEnterInformation,
     )
 }
 
 @Composable
 fun CertificationGuideScreen(
-    navigateToCertificationEnterInformation: () -> Unit
+    navigateToCertificationEnterInformation: () -> Unit,
 ) {
     Column(
         modifier =
@@ -75,6 +75,6 @@ fun CertificationGuideScreen(
 @Composable
 fun CertificationGuideScreenPreview() {
     CertificationGuideScreen(
-        navigateToCertificationEnterInformation = {}
+        navigateToCertificationEnterInformation = {},
     )
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationGuideRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationGuideRoute.kt
@@ -20,12 +20,18 @@ import org.sopt.linkareer.feature.certification.component.CertificationGuideList
 import org.sopt.linkareer.feature.certification.component.CertificationTopBar
 
 @Composable
-fun CertificationGuideRoute() {
-    CertificationGuideScreen()
+fun CertificationGuideRoute(
+    navigateToCertificationEnterInformation: () -> Unit
+) {
+    CertificationGuideScreen(
+        navigateToCertificationEnterInformation = navigateToCertificationEnterInformation
+    )
 }
 
 @Composable
-fun CertificationGuideScreen() {
+fun CertificationGuideScreen(
+    navigateToCertificationEnterInformation: () -> Unit
+) {
     Column(
         modifier =
             Modifier
@@ -55,7 +61,7 @@ fun CertificationGuideScreen() {
         Spacer(modifier = Modifier.weight(1f))
         CertificationConfirmButton(
             buttonText = R.string.certification_ok_button,
-            onClickButton = {},
+            onClickButton = navigateToCertificationEnterInformation,
             modifier =
                 Modifier
                     .padding(horizontal = 17.dp)
@@ -67,5 +73,7 @@ fun CertificationGuideScreen() {
 @Preview(showBackground = true)
 @Composable
 fun CertificationGuideScreenPreview() {
-    CertificationGuideScreen()
+    CertificationGuideScreen(
+        navigateToCertificationEnterInformation = {}
+    )
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationGuideRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/CertificationGuideRoute.kt
@@ -1,6 +1,5 @@
-package org.sopt.linkareer.feature.certification.navigation
+package org.sopt.linkareer.feature.certification
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -8,28 +7,25 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.linkareer.R
-import org.sopt.linkareer.core.designsystem.theme.Gray700
 import org.sopt.linkareer.core.designsystem.theme.Gray900
-import org.sopt.linkareer.core.designsystem.theme.LINKareerAndroidTheme
 import org.sopt.linkareer.core.designsystem.theme.White
 import org.sopt.linkareer.core.designsystem.theme.defaultLINKareerTypography
 import org.sopt.linkareer.feature.certification.component.CertificationConfirmButton
+import org.sopt.linkareer.feature.certification.component.CertificationGuideList
 import org.sopt.linkareer.feature.certification.component.CertificationTopBar
 
 @Composable
-fun CertificationCheckSuccessRoute() {
+fun CertificationGuideRoute() {
+    CertificationGuideScreen()
 }
 
 @Composable
-fun CertificationCheckSuccessScreen() {
+fun CertificationGuideScreen() {
     Column(
         modifier =
             Modifier
@@ -43,32 +39,22 @@ fun CertificationCheckSuccessScreen() {
                     .padding(top = 27.dp),
         )
         Text(
-            text = stringResource(R.string.certification_check_title),
+            text = stringResource(R.string.certification_guide_title),
             style = defaultLINKareerTypography.title3B16,
             color = Gray900,
             modifier =
                 Modifier
                     .padding(start = 17.dp, top = 16.dp),
         )
-        Text(
-            text = stringResource(R.string.certification_check_subtitle),
-            style = defaultLINKareerTypography.body10M11,
-            color = Gray700,
+        CertificationGuideList(
             modifier =
                 Modifier
-                    .padding(start = 17.dp, top = 8.dp),
-        )
-        Image(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_check_circle_144),
-            contentDescription = stringResource(R.string.certification_check_success),
-            modifier =
-                Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(top = 147.dp),
+                    .padding(horizontal = 17.dp)
+                    .padding(top = 32.dp),
         )
         Spacer(modifier = Modifier.weight(1f))
         CertificationConfirmButton(
-            buttonText = R.string.certification_confirm_button,
+            buttonText = R.string.certification_ok_button,
             onClickButton = {},
             modifier =
                 Modifier
@@ -80,8 +66,6 @@ fun CertificationCheckSuccessScreen() {
 
 @Preview(showBackground = true)
 @Composable
-fun CertificationCheckSuccessScreenPreview() {
-    LINKareerAndroidTheme {
-        CertificationCheckSuccessScreen()
-    }
+fun CertificationGuideScreenPreview() {
+    CertificationGuideScreen()
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationAddImageBox.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationAddImageBox.kt
@@ -28,7 +28,6 @@ import org.sopt.linkareer.core.designsystem.theme.LINKareerTheme
 @Composable
 fun CertificationAddImageBox(
     @DrawableRes addImage: Int?,
-    onAddImageClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val isClicked = remember { mutableStateOf(false) }
@@ -39,7 +38,6 @@ fun CertificationAddImageBox(
                 .fillMaxWidth()
                 .clickable {
                     isClicked.value = true
-                    onAddImageClick()
                 }
                 .paint(
                     painterResource(
@@ -56,18 +54,18 @@ fun CertificationAddImageBox(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Text(
-                text = stringResource(R.string.certification_add_capture),
-                style = LINKareerTheme.typography.body14R10,
-                color = Gray600,
-            )
-            Spacer(modifier = Modifier.heightIn(12.dp))
-            Image(
-                painter = painterResource(id = R.drawable.ic_regist_50),
-                contentDescription = null,
-                Modifier
-                    .clickable { onAddImageClick() },
-            )
+            if(!isClicked.value) {
+                Text(
+                    text = stringResource(R.string.certification_add_capture),
+                    style = LINKareerTheme.typography.body14R10,
+                    color = Gray600,
+                )
+                Spacer(modifier = Modifier.heightIn(12.dp))
+                Image(
+                    painter = painterResource(id = R.drawable.ic_regist_50),
+                    contentDescription = null,
+                )
+            }
         }
     }
 }
@@ -78,7 +76,6 @@ fun CertificationAddImageBoxPreview() {
     LINKareerAndroidTheme {
         CertificationAddImageBox(
             null,
-            onAddImageClick = {},
         )
     }
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationAddImageBox.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationAddImageBox.kt
@@ -54,7 +54,7 @@ fun CertificationAddImageBox(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            if(!isClicked.value) {
+            if (!isClicked.value) {
                 Text(
                     text = stringResource(R.string.certification_add_capture),
                     style = LINKareerTheme.typography.body14R10,

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationConfirmButton.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/component/CertificationConfirmButton.kt
@@ -23,6 +23,7 @@ import org.sopt.linkareer.core.designsystem.theme.White
 fun CertificationConfirmButton(
     @StringRes buttonText: Int,
     onClickButton: () -> Unit,
+    isEnabled: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Button(
@@ -32,6 +33,7 @@ fun CertificationConfirmButton(
         contentPadding = PaddingValues(horizontal = 10.dp, vertical = 12.dp),
         onClick = onClickButton,
         shape = RoundedCornerShape(8.dp),
+        enabled = isEnabled,
         colors =
             ButtonDefaults.buttonColors(
                 containerColor = Blue,
@@ -54,6 +56,7 @@ fun CertificationConfirmButtonPreview() {
         CertificationConfirmButton(
             buttonText = R.string.certification_confirm_button,
             onClickButton = {},
+            isEnabled = false,
             modifier = Modifier,
         )
     }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationCheckSuccessNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationCheckSuccessNavigation.kt
@@ -7,54 +7,9 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import kotlinx.serialization.Serializable
 import org.sopt.linkareer.core.navigation.ChattingHome
-import org.sopt.linkareer.core.navigation.Home
 import org.sopt.linkareer.core.navigation.Route
 import org.sopt.linkareer.feature.certification.CertificationCheckSuccessRoute
-import org.sopt.linkareer.feature.certification.CertificationEnterInformationRoute
-import org.sopt.linkareer.feature.certification.CertificationGuideRoute
 import org.sopt.linkareer.feature.chattingroom.navigation.navigateToChattingRoom
-import org.sopt.linkareer.feature.home.navigation.navigateToHome
-
-@Serializable
-data object CertificationGuide : Route
-
-fun NavController.navigateToCertificationGuide(navOptions: NavOptions? = null) {
-    navigate(
-        route = CertificationGuide,
-        navOptions = navOptions
-    )
-}
-
-fun NavGraphBuilder.certificationGuideGuide(
-    navHostController: NavHostController,
-) {
-    composable<CertificationGuide> {
-        CertificationGuideRoute(
-            navigateToCertificationEnterInformation = { navHostController.navigateToCertificationEnterInformation() }
-        )
-    }
-}
-
-@Serializable
-data object CertificationEnterInfo : Route
-
-fun NavController.navigateToCertificationEnterInformation(navOptions: NavOptions? = null) {
-    navigate(
-        route = CertificationEnterInfo,
-        navOptions = navOptions
-    )
-}
-
-
-fun NavGraphBuilder.certificationEnterInformation(
-    navHostController: NavHostController,
-) {
-    composable<CertificationEnterInfo> {
-        CertificationEnterInformationRoute(
-            navigateToCertificationEnterInformation = { navHostController.navigateToCertificationSuccess() }
-        )
-    }
-}
 
 @Serializable
 data object CertificationSuccess : Route
@@ -85,4 +40,3 @@ fun NavGraphBuilder.certificationSuccess(
         )
     }
 }
-

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationCheckSuccessNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationCheckSuccessNavigation.kt
@@ -17,7 +17,7 @@ data object CertificationSuccess : Route
 fun NavController.navigateToCertificationSuccess(navOptions: NavOptions? = null) {
     navigate(
         route = CertificationSuccess,
-        navOptions = navOptions
+        navOptions = navOptions,
     )
 }
 
@@ -28,15 +28,16 @@ fun NavGraphBuilder.certificationSuccess(
         CertificationCheckSuccessRoute(
             navigateToChattingRoom = {
                 navHostController.navigateToChattingRoom(
-                    navOptions = NavOptions.Builder()
-                        .setPopUpTo(
-                            route = ChattingHome,
-                            inclusive = false
-                        )
-                        .setLaunchSingleTop(true)
-                        .build()
+                    navOptions =
+                        NavOptions.Builder()
+                            .setPopUpTo(
+                                route = ChattingHome,
+                                inclusive = false,
+                            )
+                            .setLaunchSingleTop(true)
+                            .build(),
                 )
-            }
+            },
         )
     }
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationEnterNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationEnterNavigation.kt
@@ -15,17 +15,16 @@ data object CertificationEnterInfo : Route
 fun NavController.navigateToCertificationEnterInformation(navOptions: NavOptions? = null) {
     navigate(
         route = CertificationEnterInfo,
-        navOptions = navOptions
+        navOptions = navOptions,
     )
 }
-
 
 fun NavGraphBuilder.certificationEnterInformation(
     navHostController: NavHostController,
 ) {
     composable<CertificationEnterInfo> {
         CertificationEnterInformationRoute(
-            navigateToCertificationEnterInformation = { navHostController.navigateToCertificationSuccess() }
+            navigateToCertificationEnterInformation = { navHostController.navigateToCertificationSuccess() },
         )
     }
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationEnterNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationEnterNavigation.kt
@@ -1,0 +1,31 @@
+package org.sopt.linkareer.feature.certification.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import kotlinx.serialization.Serializable
+import org.sopt.linkareer.core.navigation.Route
+import org.sopt.linkareer.feature.certification.CertificationEnterInformationRoute
+
+@Serializable
+data object CertificationEnterInfo : Route
+
+fun NavController.navigateToCertificationEnterInformation(navOptions: NavOptions? = null) {
+    navigate(
+        route = CertificationEnterInfo,
+        navOptions = navOptions
+    )
+}
+
+
+fun NavGraphBuilder.certificationEnterInformation(
+    navHostController: NavHostController,
+) {
+    composable<CertificationEnterInfo> {
+        CertificationEnterInformationRoute(
+            navigateToCertificationEnterInformation = { navHostController.navigateToCertificationSuccess() }
+        )
+    }
+}

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationGuideNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationGuideNavigation.kt
@@ -15,7 +15,7 @@ data object CertificationGuide : Route
 fun NavController.navigateToCertificationGuide(navOptions: NavOptions? = null) {
     navigate(
         route = CertificationGuide,
-        navOptions = navOptions
+        navOptions = navOptions,
     )
 }
 
@@ -24,8 +24,7 @@ fun NavGraphBuilder.certificationGuideGuide(
 ) {
     composable<CertificationGuide> {
         CertificationGuideRoute(
-            navigateToCertificationEnterInformation = { navHostController.navigateToCertificationEnterInformation() }
+            navigateToCertificationEnterInformation = { navHostController.navigateToCertificationEnterInformation() },
         )
     }
 }
-

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationGuideNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationGuideNavigation.kt
@@ -1,0 +1,31 @@
+package org.sopt.linkareer.feature.certification.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import kotlinx.serialization.Serializable
+import org.sopt.linkareer.core.navigation.Route
+import org.sopt.linkareer.feature.certification.CertificationGuideRoute
+
+@Serializable
+data object CertificationGuide : Route
+
+fun NavController.navigateToCertificationGuide(navOptions: NavOptions? = null) {
+    navigate(
+        route = CertificationGuide,
+        navOptions = navOptions
+    )
+}
+
+fun NavGraphBuilder.certificationGuideGuide(
+    navHostController: NavHostController,
+) {
+    composable<CertificationGuide> {
+        CertificationGuideRoute(
+            navigateToCertificationEnterInformation = { navHostController.navigateToCertificationEnterInformation() }
+        )
+    }
+}
+

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationNavigation.kt
@@ -46,7 +46,9 @@ fun NavGraphBuilder.certificationEnterInformation(
     navHostController: NavHostController,
 ) {
     composable<CertificationEnterInfo> {
-        CertificationEnterInformationRoute()
+        CertificationEnterInformationRoute(
+            navigateToCertificationEnterInformation = { navHostController.navigateToCertificationSuccess() }
+        )
     }
 }
 
@@ -64,7 +66,7 @@ fun NavGraphBuilder.certificationSuccess(
     navHostController: NavHostController,
 ) {
     composable<CertificationSuccess> {
-        //CertificationGuideRoute()
+        CertificationCheckSuccessRoute()
     }
 }
 

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationNavigation.kt
@@ -6,10 +6,14 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import kotlinx.serialization.Serializable
+import org.sopt.linkareer.core.navigation.ChattingHome
+import org.sopt.linkareer.core.navigation.Home
 import org.sopt.linkareer.core.navigation.Route
 import org.sopt.linkareer.feature.certification.CertificationCheckSuccessRoute
 import org.sopt.linkareer.feature.certification.CertificationEnterInformationRoute
 import org.sopt.linkareer.feature.certification.CertificationGuideRoute
+import org.sopt.linkareer.feature.chattingroom.navigation.navigateToChattingRoom
+import org.sopt.linkareer.feature.home.navigation.navigateToHome
 
 @Serializable
 data object CertificationGuide : Route
@@ -66,7 +70,19 @@ fun NavGraphBuilder.certificationSuccess(
     navHostController: NavHostController,
 ) {
     composable<CertificationSuccess> {
-        CertificationCheckSuccessRoute()
+        CertificationCheckSuccessRoute(
+            navigateToChattingRoom = {
+                navHostController.navigateToChattingRoom(
+                    navOptions = NavOptions.Builder()
+                        .setPopUpTo(
+                            route = ChattingHome,
+                            inclusive = false
+                        )
+                        .setLaunchSingleTop(true)
+                        .build()
+                )
+            }
+        )
     }
 }
 

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationNavigation.kt
@@ -1,0 +1,65 @@
+package org.sopt.linkareer.feature.certification.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import kotlinx.serialization.Serializable
+import org.sopt.linkareer.core.navigation.Route
+import org.sopt.linkareer.feature.certification.CertificationGuideRoute
+
+fun NavController.navigateToCertificationGuide(navOptions: NavOptions? = null) {
+    navigate(
+        route = CertificationGuide,
+        navOptions = navOptions
+    )
+}
+
+fun NavGraphBuilder.certificationGuideGuide(
+    navHostController: NavHostController,
+) {
+    composable<CertificationGuide> {
+        CertificationGuideRoute()
+    }
+}
+
+fun NavController.navigateToCertificationEnterInfo(navOptions: NavOptions? = null) {
+    navigate(
+        route = CertificationEnterInfo,
+        navOptions = navOptions
+    )
+}
+
+fun NavGraphBuilder.certificationEnterInfo(
+    navHostController: NavHostController,
+) {
+    composable<CertificationEnterInfo> {
+        CertificationGuideRoute()
+    }
+}
+
+fun NavController.navigateToCertificationSuccess(navOptions: NavOptions? = null) {
+    navigate(
+        route = CertificationSuccess,
+        navOptions = navOptions
+    )
+}
+
+fun NavGraphBuilder.certificationSuccess(
+    navHostController: NavHostController,
+) {
+    composable<CertificationSuccess> {
+        CertificationGuideRoute()
+    }
+}
+
+@Serializable
+data object CertificationGuide : Route
+
+@Serializable
+data object CertificationEnterInfo : Route
+
+@Serializable
+data object CertificationSuccess : Route
+

--- a/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/certification/navigation/CertificationNavigation.kt
@@ -7,7 +7,12 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import kotlinx.serialization.Serializable
 import org.sopt.linkareer.core.navigation.Route
+import org.sopt.linkareer.feature.certification.CertificationCheckSuccessRoute
+import org.sopt.linkareer.feature.certification.CertificationEnterInformationRoute
 import org.sopt.linkareer.feature.certification.CertificationGuideRoute
+
+@Serializable
+data object CertificationGuide : Route
 
 fun NavController.navigateToCertificationGuide(navOptions: NavOptions? = null) {
     navigate(
@@ -20,24 +25,33 @@ fun NavGraphBuilder.certificationGuideGuide(
     navHostController: NavHostController,
 ) {
     composable<CertificationGuide> {
-        CertificationGuideRoute()
+        CertificationGuideRoute(
+            navigateToCertificationEnterInformation = { navHostController.navigateToCertificationEnterInformation() }
+        )
     }
 }
 
-fun NavController.navigateToCertificationEnterInfo(navOptions: NavOptions? = null) {
+@Serializable
+data object CertificationEnterInfo : Route
+
+fun NavController.navigateToCertificationEnterInformation(navOptions: NavOptions? = null) {
     navigate(
         route = CertificationEnterInfo,
         navOptions = navOptions
     )
 }
 
-fun NavGraphBuilder.certificationEnterInfo(
+
+fun NavGraphBuilder.certificationEnterInformation(
     navHostController: NavHostController,
 ) {
     composable<CertificationEnterInfo> {
-        CertificationGuideRoute()
+        CertificationEnterInformationRoute()
     }
 }
+
+@Serializable
+data object CertificationSuccess : Route
 
 fun NavController.navigateToCertificationSuccess(navOptions: NavOptions? = null) {
     navigate(
@@ -50,16 +64,7 @@ fun NavGraphBuilder.certificationSuccess(
     navHostController: NavHostController,
 ) {
     composable<CertificationSuccess> {
-        CertificationGuideRoute()
+        //CertificationGuideRoute()
     }
 }
-
-@Serializable
-data object CertificationGuide : Route
-
-@Serializable
-data object CertificationEnterInfo : Route
-
-@Serializable
-data object CertificationSuccess : Route
 

--- a/app/src/main/java/org/sopt/linkareer/feature/chattingroom/ChattingRoomRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/chattingroom/ChattingRoomRoute.kt
@@ -36,6 +36,7 @@ import java.time.format.DateTimeFormatter
 
 @Composable
 fun ChattingRoomRoute(
+    navigateBack: () -> Unit,
     navigateToCertificationGuide: () -> Unit,
     chatRoomViewModel: ChatRoomViewModel = hiltViewModel(),
 ) {
@@ -51,6 +52,7 @@ fun ChattingRoomRoute(
         is UiState.Success -> {
             val chatRoomStateData = (chatRoomState as UiState.Success<ChatRoomState>).data
             ChattingRoomScreen(
+                navigateBack = navigateBack,
                 navigateToCertificationGuide = navigateToCertificationGuide,
                 chatListEntity = chatRoomStateData.chatListEntity,
             )
@@ -64,6 +66,7 @@ fun ChattingRoomRoute(
 
 @Composable
 fun ChattingRoomScreen(
+    navigateBack: () -> Unit,
     navigateToCertificationGuide: () -> Unit,
     chatListEntity: ChatListEntity,
 ) {
@@ -86,7 +89,7 @@ fun ChattingRoomScreen(
         BackChattingRoomTopAppBar(
             chattingRoomName = chatListEntity.chatRoomName,
             chattingRoomHeadCount = chatListEntity.chatParticiPantsCount,
-            onBackButtonClick = { },
+            onBackButtonClick = navigateBack,
         )
         ChatRoomTopNotice()
 
@@ -183,6 +186,7 @@ fun ChattingRoomScreen(
 @Composable
 fun ChattingScreenPreview() {
     ChattingRoomScreen(
+        navigateBack = {},
         navigateToCertificationGuide = {},
         ChatListEntity(),
     )

--- a/app/src/main/java/org/sopt/linkareer/feature/chattingroom/ChattingRoomRoute.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/chattingroom/ChattingRoomRoute.kt
@@ -36,7 +36,7 @@ import java.time.format.DateTimeFormatter
 
 @Composable
 fun ChattingRoomRoute(
-    // navigateToCertification: () -> Unit,
+    navigateToCertificationGuide: () -> Unit,
     chatRoomViewModel: ChatRoomViewModel = hiltViewModel(),
 ) {
     val chatRoomState by chatRoomViewModel.chatRoomState.collectAsStateWithLifecycle()
@@ -51,6 +51,7 @@ fun ChattingRoomRoute(
         is UiState.Success -> {
             val chatRoomStateData = (chatRoomState as UiState.Success<ChatRoomState>).data
             ChattingRoomScreen(
+                navigateToCertificationGuide = navigateToCertificationGuide,
                 chatListEntity = chatRoomStateData.chatListEntity,
             )
         }
@@ -63,6 +64,7 @@ fun ChattingRoomRoute(
 
 @Composable
 fun ChattingRoomScreen(
+    navigateToCertificationGuide: () -> Unit,
     chatListEntity: ChatListEntity,
 ) {
     val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
@@ -84,7 +86,7 @@ fun ChattingRoomScreen(
         BackChattingRoomTopAppBar(
             chattingRoomName = chatListEntity.chatRoomName,
             chattingRoomHeadCount = chatListEntity.chatParticiPantsCount,
-            onBackButtonClick = {},
+            onBackButtonClick = { },
         )
         ChatRoomTopNotice()
 
@@ -154,7 +156,7 @@ fun ChattingRoomScreen(
         }
 
         ChatRoomBottomNotice(
-            onClickToCheck = {},
+            onClickToCheck = navigateToCertificationGuide,
             modifier =
                 Modifier
                     .padding(horizontal = 18.dp),
@@ -181,6 +183,7 @@ fun ChattingRoomScreen(
 @Composable
 fun ChattingScreenPreview() {
     ChattingRoomScreen(
+        navigateToCertificationGuide = {},
         ChatListEntity(),
     )
 }

--- a/app/src/main/java/org/sopt/linkareer/feature/chattingroom/navigation/ChattingRoomNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/chattingroom/navigation/ChattingRoomNavigation.kt
@@ -22,6 +22,7 @@ fun NavGraphBuilder.chattingRoomGraph(
 ) {
     composable<ChattingRoom> {
         ChattingRoomRoute(
+            navigateBack = {navHostController.popBackStack()},
             navigateToCertificationGuide = { navHostController.navigateToCertificationGuide() },
         )
     }

--- a/app/src/main/java/org/sopt/linkareer/feature/chattingroom/navigation/ChattingRoomNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/chattingroom/navigation/ChattingRoomNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import kotlinx.serialization.Serializable
 import org.sopt.linkareer.core.navigation.Route
+import org.sopt.linkareer.feature.certification.navigation.navigateToCertificationGuide
 import org.sopt.linkareer.feature.chattingroom.ChattingRoomRoute
 
 fun NavController.navigateToChattingRoom(navOptions: NavOptions? = null) {
@@ -20,7 +21,9 @@ fun NavGraphBuilder.chattingRoomGraph(
     navHostController: NavHostController,
 ) {
     composable<ChattingRoom> {
-        ChattingRoomRoute()
+        ChattingRoomRoute(
+            navigateToCertificationGuide = { navHostController.navigateToCertificationGuide() },
+        )
     }
 }
 

--- a/app/src/main/java/org/sopt/linkareer/feature/chattingroom/navigation/ChattingRoomNavigation.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/chattingroom/navigation/ChattingRoomNavigation.kt
@@ -22,7 +22,7 @@ fun NavGraphBuilder.chattingRoomGraph(
 ) {
     composable<ChattingRoom> {
         ChattingRoomRoute(
-            navigateBack = {navHostController.popBackStack()},
+            navigateBack = { navHostController.popBackStack() },
             navigateToCertificationGuide = { navHostController.navigateToCertificationGuide() },
         )
     }

--- a/app/src/main/java/org/sopt/linkareer/feature/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/main/MainScreen.kt
@@ -23,6 +23,7 @@ import org.sopt.linkareer.core.designsystem.theme.Gray900
 import org.sopt.linkareer.core.designsystem.theme.LINKareerTheme
 import org.sopt.linkareer.core.designsystem.theme.White
 import org.sopt.linkareer.core.util.NoRippleInteraction
+import org.sopt.linkareer.feature.certification.navigation.certificationEnterInformation
 import org.sopt.linkareer.feature.certification.navigation.certificationGuideGuide
 import org.sopt.linkareer.feature.chattinghome.navigation.chattingHomeGraph
 import org.sopt.linkareer.feature.chattingroom.navigation.chattingRoomGraph
@@ -83,6 +84,9 @@ fun MainScreen(
                 )
                 certificationGuideGuide(
                     navHostController = navigator.navController,
+                )
+                certificationEnterInformation(
+                    navHostController = navigator.navController
                 )
             }
         }

--- a/app/src/main/java/org/sopt/linkareer/feature/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/main/MainScreen.kt
@@ -23,6 +23,7 @@ import org.sopt.linkareer.core.designsystem.theme.Gray900
 import org.sopt.linkareer.core.designsystem.theme.LINKareerTheme
 import org.sopt.linkareer.core.designsystem.theme.White
 import org.sopt.linkareer.core.util.NoRippleInteraction
+import org.sopt.linkareer.feature.certification.navigation.certificationGuideGuide
 import org.sopt.linkareer.feature.chattinghome.navigation.chattingHomeGraph
 import org.sopt.linkareer.feature.chattingroom.navigation.chattingRoomGraph
 import org.sopt.linkareer.feature.home.navigation.homeNavGraph
@@ -78,6 +79,9 @@ fun MainScreen(
                     navHostController = navigator.navController,
                 )
                 chattingRoomGraph(
+                    navHostController = navigator.navController,
+                )
+                certificationGuideGuide(
                     navHostController = navigator.navController,
                 )
             }

--- a/app/src/main/java/org/sopt/linkareer/feature/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/main/MainScreen.kt
@@ -25,6 +25,7 @@ import org.sopt.linkareer.core.designsystem.theme.White
 import org.sopt.linkareer.core.util.NoRippleInteraction
 import org.sopt.linkareer.feature.certification.navigation.certificationEnterInformation
 import org.sopt.linkareer.feature.certification.navigation.certificationGuideGuide
+import org.sopt.linkareer.feature.certification.navigation.certificationSuccess
 import org.sopt.linkareer.feature.chattinghome.navigation.chattingHomeGraph
 import org.sopt.linkareer.feature.chattingroom.navigation.chattingRoomGraph
 import org.sopt.linkareer.feature.home.navigation.homeNavGraph
@@ -86,6 +87,9 @@ fun MainScreen(
                     navHostController = navigator.navController,
                 )
                 certificationEnterInformation(
+                    navHostController = navigator.navController
+                )
+                certificationSuccess(
                     navHostController = navigator.navController
                 )
             }

--- a/app/src/main/java/org/sopt/linkareer/feature/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/linkareer/feature/main/MainScreen.kt
@@ -87,10 +87,10 @@ fun MainScreen(
                     navHostController = navigator.navController,
                 )
                 certificationEnterInformation(
-                    navHostController = navigator.navController
+                    navHostController = navigator.navController,
                 )
                 certificationSuccess(
-                    navHostController = navigator.navController
+                    navHostController = navigator.navController,
                 )
             }
         }


### PR DESCRIPTION
## Related issue 🛠
- closed #45

## Work Description ✏️
- 채팅방에서 인증 안내 화면으로 이동
- 인증 안내 화면에서 인증 정보 입력 화면으로 이동
- 인증 정보 입력 화면에서 인증 완료 화면으로 이동
- 인증 완료 화면에서 채팅방으로 이동
- 인증 완료 후 채팅방으로 되돌아 온 뒤 뒤로가기 하면 채팅 목록 화면으로 이동
- 홈 화면 탭바 LazyRow로 수정 

## Screenshot 📸
<img src="https://github.com/user-attachments/assets/eed9a530-ca86-4e6b-a436-0b88b35ea7e6" width="360"/>

## To Reviewers 📢
- 인증 완료 후 채팅방으로 되돌아 온 후 뒤로가기 하면 채팅 목록 화면으로 가집니다.
